### PR TITLE
HFP34- [fix]  정산페이지 라우터연결

### DIFF
--- a/freebridgefe/src/layouts/PlatformLayout.vue
+++ b/freebridgefe/src/layouts/PlatformLayout.vue
@@ -34,6 +34,7 @@ const employerNavItems = [
   { id: 'employer.freelancers', path: '/employer/freelancers', label: '프리랜서 찾기', icon: Users },
   { id: 'employer.recommended', path: '/employer/recommended', label: '추천 프리랜서', icon: TrendingUp },
   { id: 'employer.contracts', path: '/employer/contracts', label: '계약서', icon: FileCheck },
+  { id: 'employer.settlement', path: '/employer/settlement', label: '정산', icon: Wallet },
   { id: 'employer.mypage', path: '/employer/mypage', label: '마이페이지', icon: UserCircle },
 ];
 

--- a/freebridgefe/src/layouts/PlatformLayout.vue
+++ b/freebridgefe/src/layouts/PlatformLayout.vue
@@ -15,6 +15,7 @@ import {
   Wallet,
   UserCircle,
   MessageSquareQuote,
+  HelpCircle,
 } from 'lucide-vue-next';
 
 const router = useRouter();
@@ -73,10 +74,10 @@ onMounted(() => {
   <div v-if="currentUser" class="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-gray-900 font-sans">
     <!-- Desktop Navigation -->
     <nav class="hidden lg:block sticky top-0 z-50 h-20 bg-white/5 backdrop-blur-2xl border-b border-white/10">
-      <div class="max-w-[1400px] mx-auto px-8 h-full flex items-center justify-between">
+      <div class="w-full px-4 xl:px-8 h-full flex items-center justify-between gap-4">
         <div 
           @click="router.push(isEmployer ? '/employer/dashboard' : '/freelancer/jobs')"
-          class="text-2xl font-bold bg-gradient-to-r from-white to-white/50 bg-clip-text text-transparent cursor-pointer"
+          class="shrink-0 text-2xl font-bold bg-gradient-to-r from-white to-white/50 bg-clip-text text-transparent cursor-pointer"
           :data-tour="isEmployer ? 'employer.dashboard' : undefined"
           v-motion="{
             initial: { opacity: 0, x: -20 },
@@ -86,34 +87,36 @@ onMounted(() => {
           FreeBridge
         </div>
 
-        <div class="flex items-center gap-2">
-          <button
-            v-for="(item, index) in navItems"
-            :key="item.id"
-            @click="navigate(item.path)"
-            class="relative flex items-center gap-2 px-4 py-2.5 rounded-full transition-all"
-            :class="isActive(item.path) ? 'text-white' : 'text-white/60 hover:text-white hover:bg-white/5'"
-            :data-tour="item.id"
-            v-motion="{
-              initial: { opacity: 0, y: -10 },
-              enter: { opacity: 1, y: 0, transition: { delay: index * 100 } },
-              hover: { scale: 1.05 },
-              tap: { scale: 0.95 }
-            }"
-          >
-            <div
-              v-if="isActive(item.path)"
-              class="absolute inset-0 bg-white/10 rounded-full border border-white/20"
-              v-motion
-              layoutId="activeTab"
-            />
-            <component :is="item.icon" class="w-5 h-5 relative z-10" />
-            <span class="relative z-10 font-medium">{{ item.label }}</span>
-          </button>
+        <div class="flex-1 flex items-center justify-center min-w-0 mx-4 md:mx-6">
+          <div class="flex items-center gap-2 py-2 px-1 w-auto justify-center">
+            <button
+              v-for="(item, index) in navItems"
+              :key="item.id"
+              @click="navigate(item.path)"
+              class="shrink-0 relative flex items-center gap-2 px-4 py-2.5 rounded-full transition-all whitespace-nowrap"
+              :class="isActive(item.path) ? 'text-white' : 'text-white/60 hover:text-white hover:bg-white/5'"
+              :data-tour="item.id"
+              v-motion="{
+                initial: { opacity: 0, y: -10 },
+                enter: { opacity: 1, y: 0, transition: { delay: index * 100 } },
+                hover: { scale: 1.05 },
+                tap: { scale: 0.95 }
+              }"
+            >
+              <div
+                v-if="isActive(item.path)"
+                class="absolute inset-0 bg-white/10 rounded-full border border-white/20"
+                v-motion
+                layoutId="activeTab"
+              />
+              <component :is="item.icon" class="w-5 h-5 relative z-10" />
+              <span class="relative z-10 font-medium">{{ item.label }}</span>
+            </button>
+          </div>
         </div>
 
-        <div class="flex items-center gap-3">
-          <div class="px-4 py-2.5 bg-white/5 backdrop-blur-xl rounded-full border border-white/10">
+        <div class="shrink-0 flex items-center gap-3">
+          <div class="px-4 py-2.5 bg-white/5 backdrop-blur-xl rounded-full border border-white/10 hidden xl:block">
             <div class="text-xs text-white/50">
               {{ isEmployer ? '고용주' : '프리랜서' }}
             </div>
@@ -121,14 +124,15 @@ onMounted(() => {
           </div>
           <button
             @click="handleOpenGuide"
-            class="flex items-center gap-2 px-4 py-2.5 bg-white/5 hover:bg-white/10 rounded-full transition-all border border-white/10"
+            class="flex items-center gap-2 px-4 py-2.5 bg-white/5 hover:bg-white/10 rounded-full transition-all border border-white/10 whitespace-nowrap"
             v-motion="{
               hover: { scale: 1.05 },
               tap: { scale: 0.95 }
             }"
           >
             <HelpCircle class="w-5 h-5 text-white/80" />
-            <span class="font-medium text-white/90">이용 가이드</span>
+            <span class="font-medium text-white/90 hidden xl:inline">이용 가이드</span>
+            <span class="font-medium text-white/90 xl:hidden">가이드</span>
           </button>
           <button
             @click="handleLogout"
@@ -224,3 +228,13 @@ onMounted(() => {
     </main>
   </div>
 </template>
+
+<style scoped>
+.scrollbar-hide::-webkit-scrollbar {
+    display: none;
+}
+.scrollbar-hide {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+</style>

--- a/freebridgefe/src/router/index.ts
+++ b/freebridgefe/src/router/index.ts
@@ -67,6 +67,11 @@ const routes: Array<RouteRecordRaw> = [
                 component: () => import('@/views/employer/Contracts/ContractsView.vue')
             },
             {
+                path: 'settlement',
+                name: 'employer.settlement',
+                component: () => import('@/views/freelancer/Settlement/SettlementView.vue')
+            },
+            {
                 path: 'mypage',
                 name: 'employer.mypage',
                 component: () => import('@/views/employer/MyPage/MyPageView.vue')

--- a/freebridgefe/src/stores/authStore.ts
+++ b/freebridgefe/src/stores/authStore.ts
@@ -5,7 +5,21 @@ import type { User } from '@/types';
 export const useAuthStore = defineStore('auth', () => {
     // Initialize from localStorage if available
     const savedUser = localStorage.getItem('user');
-    const user = ref<User | null>(savedUser ? JSON.parse(savedUser) : null);
+    let initialUser: User | null = null;
+    if (savedUser) {
+        try {
+            initialUser = JSON.parse(savedUser);
+            if (initialUser?.createdAt) {
+                initialUser.createdAt = new Date(initialUser.createdAt);
+            }
+            if (initialUser?.agreedToTermsAt) {
+                initialUser.agreedToTermsAt = new Date(initialUser.agreedToTermsAt);
+            }
+        } catch (e) {
+            console.error('Failed to restore user from localStorage', e);
+        }
+    }
+    const user = ref<User | null>(initialUser);
     const isLoading = ref(false);
 
     const isAuthenticated = computed(() => !!user.value);

--- a/freebridgefe/src/stores/authStore.ts
+++ b/freebridgefe/src/stores/authStore.ts
@@ -6,6 +6,7 @@ export const useAuthStore = defineStore('auth', () => {
     // Initialize from localStorage if available
     const savedUser = localStorage.getItem('user');
     const user = ref<User | null>(savedUser ? JSON.parse(savedUser) : null);
+    const isLoading = ref(false);
 
     const isAuthenticated = computed(() => !!user.value);
 
@@ -19,16 +20,41 @@ export const useAuthStore = defineStore('auth', () => {
         localStorage.removeItem('user');
     }
 
-    function signup(userData: User) {
-        user.value = userData;
-        localStorage.setItem('user', JSON.stringify(userData));
+    async function checkEmailDuplicate(email: string): Promise<boolean> {
+        // TODO: Replace with actual API call
+        // return await api.post('/auth/check-email', { email });
+
+        // Mock: Always available
+        return new Promise(resolve => setTimeout(() => resolve(true), 500));
+    }
+
+    async function signup(userData: User) {
+        isLoading.value = true;
+        try {
+            // TODO: Replace with actual API call
+            // const response = await api.post('/auth/signup', userData);
+            // user.value = response.data;
+
+            // Mock: Simulate network delay
+            await new Promise(resolve => setTimeout(resolve, 1500));
+
+            user.value = userData;
+            localStorage.setItem('user', JSON.stringify(userData));
+        } catch (error) {
+            console.error('Signup failed:', error);
+            throw error;
+        } finally {
+            isLoading.value = false;
+        }
     }
 
     return {
         user,
         isAuthenticated,
+        isLoading,
         login,
         logout,
-        signup
+        signup,
+        checkEmailDuplicate
     };
 });

--- a/freebridgefe/src/types/index.ts
+++ b/freebridgefe/src/types/index.ts
@@ -10,6 +10,9 @@ export interface User {
     name: string;
     email: string;
     avatar?: string;
+    createdAt?: Date;
+    agreedToTermsAt?: Date;
+    isEmailVerified?: boolean;
     // Freelancer specific
     skills?: string[];
     hourlyRate?: number;

--- a/freebridgefe/src/types/index.ts
+++ b/freebridgefe/src/types/index.ts
@@ -10,8 +10,8 @@ export interface User {
     name: string;
     email: string;
     avatar?: string;
-    createdAt?: Date;
-    agreedToTermsAt?: Date;
+    createdAt?: string | Date;
+    agreedToTermsAt?: string | Date;
     isEmailVerified?: boolean;
     // Freelancer specific
     skills?: string[];

--- a/freebridgefe/src/views/Guide/UserGuideView.vue
+++ b/freebridgefe/src/views/Guide/UserGuideView.vue
@@ -164,6 +164,14 @@ const freelancerGuides = [
 ];
 
 const currentGuides = computed(() => activeTab.value === 'EMPLOYER' ? employerGuides : freelancerGuides);
+
+const handleReturnToService = () => {
+  if (currentUser.value) {
+    router.push(currentUser.value.role === 'EMPLOYER' ? '/employer/dashboard' : '/freelancer/jobs');
+  } else {
+    router.push('/');
+  }
+};
 </script>
 
 <template>
@@ -280,7 +288,7 @@ const currentGuides = computed(() => activeTab.value === 'EMPLOYER' ? employerGu
       <!-- 하단 CTA -->
       <div class="mt-20 text-center">
         <button
-          @click="window.history.length > 1 ? router.go(-1) : router.push('/')"
+          @click="handleReturnToService"
           class="inline-flex items-center gap-2 px-8 py-4 bg-white/10 hover:bg-white/20 rounded-full font-bold text-white transition-all backdrop-blur-md border border-white/10"
         >
           <span>서비스로 돌아가기</span>

--- a/freebridgefe/src/views/auth/SignupView.vue
+++ b/freebridgefe/src/views/auth/SignupView.vue
@@ -2,16 +2,6 @@
 import { ref, computed, onMounted, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 // ...
-const toggleConfirmPassword = () => {
-  showConfirmPassword.value = !showConfirmPassword.value;
-};
-
-// Reset email availability when email changes
-watch(() => formData.value.email, () => {
-  isEmailAvailable.value = false;
-});
-
-const checkEmail = async () => {
 import { useAuthStore } from '@/stores/authStore';
 import { Mail, Lock, User as UserIcon, Building2, ArrowLeft, Eye, EyeOff, Check } from 'lucide-vue-next';
 import AnimatedBackground from './components/AnimatedBackground.vue';
@@ -154,7 +144,10 @@ const handleSubmit = async () => {
       role: role.value,
       createdAt: new Date(),
       agreedToTermsAt: new Date(),
-      isEmailVerified: false
+      isEmailVerified: false,
+      skills: !isEmployer.value 
+        ? formData.value.skills.split(',').map(s => s.trim()).filter(s => s.length > 0) 
+        : undefined
     };
 
     // Mock Signup
@@ -179,6 +172,10 @@ const goBack = () => {
 
 const togglePassword = () => {
   showPassword.value = !showPassword.value;
+};
+
+const toggleConfirmPassword = () => {
+  showConfirmPassword.value = !showConfirmPassword.value;
 };
 
 // Reset email availability when email changes

--- a/freebridgefe/src/views/auth/SignupView.vue
+++ b/freebridgefe/src/views/auth/SignupView.vue
@@ -1,6 +1,17 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
+// ...
+const toggleConfirmPassword = () => {
+  showConfirmPassword.value = !showConfirmPassword.value;
+};
+
+// Reset email availability when email changes
+watch(() => formData.value.email, () => {
+  isEmailAvailable.value = false;
+});
+
+const checkEmail = async () => {
 import { useAuthStore } from '@/stores/authStore';
 import { Mail, Lock, User as UserIcon, Building2, ArrowLeft, Eye, EyeOff, Check } from 'lucide-vue-next';
 import AnimatedBackground from './components/AnimatedBackground.vue';
@@ -170,9 +181,11 @@ const togglePassword = () => {
   showPassword.value = !showPassword.value;
 };
 
-const toggleConfirmPassword = () => {
-  showConfirmPassword.value = !showConfirmPassword.value;
-};
+// Reset email availability when email changes
+watch(() => formData.value.email, () => {
+  isEmailAvailable.value = false;
+});
+
 const checkEmail = async () => {
   if (!formData.value.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.value.email)) return;
   

--- a/freebridgefe/src/views/auth/SignupView.vue
+++ b/freebridgefe/src/views/auth/SignupView.vue
@@ -35,6 +35,8 @@ const formData = ref({
 const showPassword = ref(false);
 const showConfirmPassword = ref(false);
 const errors = ref<Record<string, string>>({});
+const isEmailChecking = ref(false);
+const isEmailAvailable = ref(false);
 
 // Terms Modal State
 const showTermsModal = ref(false);
@@ -93,12 +95,16 @@ const validateForm = () => {
     newErrors.email = '이메일을 입력해주세요';
   } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.value.email)) {
     newErrors.email = '올바른 이메일 형식이 아닙니다';
+  } else if (!isEmailAvailable.value) {
+    newErrors.email = '이미 사용 중이거나 확인되지 않은 이메일입니다';
   }
 
   if (!formData.value.password) {
     newErrors.password = '비밀번호를 입력해주세요';
   } else if (formData.value.password.length < 8) {
     newErrors.password = '비밀번호는 8자 이상이어야 합니다';
+  } else if (!/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/.test(formData.value.password)) {
+    newErrors.password = '영문, 숫자, 특수문자를 포함해야 합니다';
   }
 
   if (formData.value.password !== formData.value.confirmPassword) {
@@ -129,22 +135,30 @@ const handleSubmit = () => {
 
   if (!validateForm()) return;
 
-  const newUser: User = {
-    id: isEmployer.value ? 'e-new' : 'f-new',
-    name: formData.value.name,
-    email: formData.value.email,
-    role: role.value,
-  };
+  try {
+    const newUser: User = {
+      id: isEmployer.value ? 'e-new' : 'f-new',
+      name: formData.value.name,
+      email: formData.value.email,
+      role: role.value,
+      createdAt: new Date(),
+      agreedToTermsAt: new Date(),
+      isEmailVerified: false
+    };
 
-  // Mock Signup
-  authStore.signup(newUser);
-  alert(`회원가입이 완료되었습니다!\n환영합니다, ${formData.value.name}님 🎉`);
-  
-  // Redirect to dashboard based on role (Mock)
-  if (isEmployer.value) {
-      router.push('/employer/dashboard');
-  } else {
-      router.push('/freelancer/jobs');
+    // Mock Signup
+    await authStore.signup(newUser);
+    
+    alert(`회원가입이 완료되었습니다!\n환영합니다, ${formData.value.name}님 🎉`);
+    
+    // Redirect to dashboard based on role (Mock)
+    if (isEmployer.value) {
+        router.push('/employer/dashboard');
+    } else {
+        router.push('/freelancer/jobs');
+    }
+  } catch (error) {
+    alert('회원가입 중 오류가 발생했습니다. 다시 시도해주세요.');
   }
 };
 
@@ -158,6 +172,24 @@ const togglePassword = () => {
 
 const toggleConfirmPassword = () => {
   showConfirmPassword.value = !showConfirmPassword.value;
+};
+const checkEmail = async () => {
+  if (!formData.value.email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.value.email)) return;
+  
+  isEmailChecking.value = true;
+  try {
+    const isAvailable = await authStore.checkEmailDuplicate(formData.value.email);
+    isEmailAvailable.value = isAvailable;
+    if (!isAvailable) {
+      errors.value.email = '이미 사용 중인 이메일입니다';
+    } else {
+      delete errors.value.email;
+    }
+  } catch (e) {
+    console.error(e);
+  } finally {
+    isEmailChecking.value = false;
+  }
 };
 </script>
 
@@ -275,17 +307,22 @@ const toggleConfirmPassword = () => {
             <label class="block text-sm font-medium mb-2 text-white/80">
               이메일 <span class="text-red-400">*</span>
             </label>
-            <div class="relative">
-              <Mail class="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-white/40" />
-              <input
-                type="email"
-                v-model="formData.email"
-                placeholder="your@email.com"
-                class="w-full pl-12 pr-4 py-4 bg-white/5 border rounded-2xl focus:outline-none transition-colors text-white placeholder:text-white/30"
-                :class="errors.email ? 'border-red-500/50' : 'border-white/10 focus:border-white/30'"
-              />
-            </div>
-            <p v-if="errors.email" class="text-red-400 text-sm mt-2">{{ errors.email }}</p>
+              <div class="relative">
+                <Mail class="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-white/40" />
+                <input
+                  type="email"
+                  v-model="formData.email"
+                  @blur="checkEmail"
+                  placeholder="your@email.com"
+                  class="w-full pl-12 pr-4 py-4 bg-white/5 border rounded-2xl focus:outline-none transition-colors text-white placeholder:text-white/30"
+                  :class="errors.email ? 'border-red-500/50' : (isEmailAvailable ? 'border-green-500/50' : 'border-white/10 focus:border-white/30')"
+                />
+                <div v-if="isEmailChecking" class="absolute right-4 top-1/2 -translate-y-1/2">
+                  <div class="w-4 h-4 border-2 border-white/20 border-t-white rounded-full animate-spin"></div>
+                </div>
+                <Check v-else-if="isEmailAvailable && !errors.email" class="absolute right-4 top-1/2 -translate-y-1/2 w-4 h-4 text-green-500" />
+              </div>
+              <p v-if="errors.email" class="text-red-400 text-sm mt-2">{{ errors.email }}</p>
           </div>
 
           <!-- Skills (Freelancer Only) -->
@@ -322,7 +359,7 @@ const toggleConfirmPassword = () => {
               <input
                 :type="showPassword ? 'text' : 'password'"
                 v-model="formData.password"
-                placeholder="8자 이상"
+                placeholder="영문, 숫자, 특수문자 포함 8자 이상"
                 class="w-full pl-12 pr-12 py-4 bg-white/5 border rounded-2xl focus:outline-none transition-colors text-white placeholder:text-white/30"
                 :class="errors.password ? 'border-red-500/50' : 'border-white/10 focus:border-white/30'"
               />
@@ -466,13 +503,15 @@ const toggleConfirmPassword = () => {
           <!-- Submit Button -->
           <button
             type="submit"
+            :disabled="authStore.isLoading"
             v-motion
             :initial="{ opacity: 0, y: 10 }"
             :enter="{ opacity: 1, y: 0, transition: { delay: 1200 } }"
-            class="w-full py-4 text-white rounded-2xl font-semibold text-lg hover:shadow-2xl transition-transform hover:scale-102 active:scale-98"
+            class="w-full py-4 text-white rounded-2xl font-semibold text-lg hover:shadow-2xl transition-all hover:scale-102 active:scale-98 disabled:opacity-70 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             :class="isEmployer ? 'bg-gradient-to-r from-purple-500 to-pink-500' : 'bg-gradient-to-r from-blue-500 to-cyan-500'"
           >
-            가입 완료
+            <div v-if="authStore.isLoading" class="w-5 h-5 border-2 border-white/20 border-t-white rounded-full animate-spin"></div>
+            <span>{{ authStore.isLoading ? '가입 처리중...' : '가입 완료' }}</span>
           </button>
         </form>
 
@@ -483,6 +522,7 @@ const toggleConfirmPassword = () => {
           :enter="{ opacity: 1, transition: { delay: 1300 } }"
           class="mt-6 text-center"
         >
+          <p class="text-sm text-white/50">
             이미 계정이 있으신가요? 
             <button @click="goBack" class="text-white hover:underline font-medium">
               로그인하기


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #20 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
 정산페이지 라우터연결 끊김 및 가이드페이지 되돌아가기 요소 동작하지 않는문제 수정
## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원가입 중 이메일 중복 확인 API 연동 인터페이스 및 로딩 상태 공개(isLoading, checkEmailDuplicate)
  * 고용주용 정산 페이지 추가
  * 가이드 화면의 역할 기반 복귀 동작 추가

* **개선사항**
  * 상단 내비게이션 레이아웃 및 반응형 정렬 개선(브랜드·네비·우측 컨트롤 재배치, 스크롤바 숨김)
  * 회원가입 UX 향상(비동기 처리, 로딩 스피너·비활성화, 실시간 이메일 유효성 피드백)
  * 사용자 타입에 생성일·약관동의일·이메일검증 상태 필드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->