### PR TITLE
HFP-53 [fix] 마이페이지 FE QA 수정사항

### DIFF
--- a/freebridgefe/src/api/MyPage/evaluationApi.ts
+++ b/freebridgefe/src/api/MyPage/evaluationApi.ts
@@ -94,6 +94,7 @@ export interface RejectionFeedback {
     projectName: string;
     reason: string;
     createdAt: string;
+    tags?: string[];
 }
 
 export const MOCK_REJECTION_FEEDBACKS: RejectionFeedback[] = [
@@ -102,14 +103,16 @@ export const MOCK_REJECTION_FEEDBACKS: RejectionFeedback[] = [
         companyName: '넥스트레벨',
         projectName: '쇼핑몰 고도화 프로젝트',
         reason: '포트폴리오는 훌륭했으나, 저희가 현재 도입하려는 Vue 3 Composition API 경험이 다소 부족해 보여 아쉽게도 함께하지 못하게 되었습니다.',
-        createdAt: '2025-12-05'
+        createdAt: '2025-12-05',
+        tags: ['기술 스택 불일치']
     },
     {
         id: 2,
         companyName: 'Global IT',
         projectName: '사내 메신저 개발',
         reason: '제시해주신 견적이 저희 내부 예산 범위를 초과하여 부득이하게 계약을 진행하기 어렵게 되었습니다.',
-        createdAt: '2025-11-10'
+        createdAt: '2025-11-10',
+        tags: ['예산 초과']
     }
 ];
 

--- a/freebridgefe/src/api/MyPage/freelancerApi.ts
+++ b/freebridgefe/src/api/MyPage/freelancerApi.ts
@@ -10,7 +10,7 @@ export interface FreelancerProfileDashboard {
     job: string;
     introduction: string;
     careerYears: number;
-    salary: string;
+    salary: number;
     workConditions: {
         type: string;
         startDate: string;

--- a/freebridgefe/src/api/MyPage/freelancerApi.ts
+++ b/freebridgefe/src/api/MyPage/freelancerApi.ts
@@ -39,6 +39,11 @@ export interface FreelancerProfileDashboard {
         fileName: string;
         lastUpdated: string;
     };
+    aiSummary: {
+        title: string;
+        description: string;
+    };
+    topPercentile: number;
 }
 
 export const getFreelancerProfile = async (userId: string): Promise<FreelancerProfileDashboard> => {

--- a/freebridgefe/src/api/MyPage/freelancerApi.ts
+++ b/freebridgefe/src/api/MyPage/freelancerApi.ts
@@ -39,11 +39,11 @@ export interface FreelancerProfileDashboard {
         fileName: string;
         lastUpdated: string;
     };
-    aiSummary: {
+    aiSummary?: {
         title: string;
         description: string;
     };
-    topPercentile: number;
+    topPercentile?: number;
 }
 
 export const getFreelancerProfile = async (userId: string): Promise<FreelancerProfileDashboard> => {

--- a/freebridgefe/src/api/MyPage/mock/mockProfiles.ts
+++ b/freebridgefe/src/api/MyPage/mock/mockProfiles.ts
@@ -5,7 +5,7 @@ export interface MockFreelancerProfile {
     job: string;
     introduction: string;
     careerYears: number;
-    salary: string;
+    salary: number;
     workConditions: {
         type: string;
         startDate: string;
@@ -77,7 +77,7 @@ const state: MockProfileState = {
         job: '개발자',
         introduction: '사용자 경험을 최우선으로 생각하는 프론트엔드 개발자입니다. 유지보수성과 확장성을 고려해 코드를 작성합니다.',
         careerYears: 5,
-        salary: '월 800만원',
+        salary: 50000,
         workConditions: {
             type: '개인',
             startDate: '2024-02-01',

--- a/freebridgefe/src/api/MyPage/mock/mockProfiles.ts
+++ b/freebridgefe/src/api/MyPage/mock/mockProfiles.ts
@@ -107,7 +107,7 @@ const state: MockProfileState = {
             lastUpdated: '2024.02.10'
         },
         aiSummary: {
-            title: "문제 해결 능력이 뛰어나고 <span class='text-indigo-400'>원활한 소통</span>이 강점입니다.",
+            title: "문제 해결 능력이 뛰어나고 원활한 소통이 강점입니다.",
             description: "대부분의 고용주가 귀하의 일정 준수와 문제 해결 역량을 높게 평가했습니다. 특히 협업 과정에서의 적극적인 태도가 프로젝트 성공에 기여했다는 피드백이 많습니다."
         },
         topPercentile: 10

--- a/freebridgefe/src/api/MyPage/mock/mockProfiles.ts
+++ b/freebridgefe/src/api/MyPage/mock/mockProfiles.ts
@@ -105,7 +105,12 @@ const state: MockProfileState = {
             fileUrl: '#',
             fileName: 'Portfolio_2024_v2.pdf',
             lastUpdated: '2024.02.10'
-        }
+        },
+        aiSummary: {
+            title: "문제 해결 능력이 뛰어나고 <span class='text-indigo-400'>원활한 소통</span>이 강점입니다.",
+            description: "대부분의 고용주가 귀하의 일정 준수와 문제 해결 역량을 높게 평가했습니다. 특히 협업 과정에서의 적극적인 태도가 프로젝트 성공에 기여했다는 피드백이 많습니다."
+        },
+        topPercentile: 10
     },
     employerProfile: {
         companyName: '테크스타트업',

--- a/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
@@ -17,6 +17,7 @@ import {
   Check,
   Edit3,
   Upload,
+  Download,
 } from 'lucide-vue-next';
 import { useAuthStore } from '@/stores/authStore.ts';
 import { getFreelancerProfile, type FreelancerProfileDashboard } from '@/api/MyPage/freelancerApi.ts';
@@ -52,7 +53,7 @@ const profile = ref<FreelancerProfileDashboard>({
     job: '',
     introduction: '',
     careerYears: 0,
-    salary: '',
+    salary: 0,
     workConditions: {
         type: '',
         startDate: '',
@@ -252,23 +253,13 @@ const handlePortfolioUpload = () => {
                              <div class="flex justify-between items-center text-sm">
                                 <span class="text-slate-500 font-medium w-24">희망 몸값</span>
                                 <div class="flex-1 flex justify-end">
-                                    <span class="text-white font-bold">{{ profile.salary }}</span>
+                                    <span class="text-white font-bold">{{ profile.salary.toLocaleString() }}원/시간</span>
                                 </div>
                             </div>
                         </div>
                     </div>
 
-                     <div class="bg-[#0F172A]/50 border-t border-white/5 py-3 px-6 rounded-b-2xl flex justify-center items-center">
-                        <button class="text-xs text-slate-400 flex items-center gap-1 group">
-                            최신 업데이트 프로필로 정확한 추천 정보를 받으세요!
-                            <span 
-                                @click="activeTab = 'edit'"
-                                class="font-bold text-white underline underline-offset-2 ml-1 decoration-slate-500 group-hover:decoration-white transition-all cursor-pointer"
-                            >
-                                프로필 업데이트하기
-                            </span>
-                        </button>
-                    </div>
+
                 </div>
             </div>
 
@@ -357,7 +348,7 @@ const handlePortfolioUpload = () => {
                 <div class="bg-[#1e293b]/50 rounded-2xl p-6 border border-white/5 backdrop-blur-sm h-full flex flex-col">
                     <div class="flex justify-between items-center mb-6">
                         <h4 class="font-bold text-base text-white">고용주 평가</h4>
-                        <button class="text-slate-500 hover:text-white transition-colors"><Plus class="w-4 h-4" /></button>
+                        <button @click="activeTab = 'evaluation'" class="text-slate-500 hover:text-white transition-colors"><Plus class="w-4 h-4" /></button>
                     </div>
                     <div class="flex gap-4 mb-4 flex-1">
                         <div class="w-24 h-24 bg-slate-800 rounded-xl flex items-center justify-center border border-white/5 flex-col gap-1">
@@ -434,7 +425,7 @@ const handlePortfolioUpload = () => {
                 <div class="bg-[#1e293b]/50 rounded-2xl p-6 border border-white/5 backdrop-blur-sm h-full flex flex-col">
                     <div class="flex justify-between items-center mb-6">
                         <h4 class="font-bold text-base text-white">포트폴리오</h4>
-                        <button class="text-slate-500 hover:text-white transition-colors"><Upload class="w-4 h-4" /></button>
+                        <button @click="handlePortfolioUpload" class="text-slate-500 hover:text-white transition-colors"><Upload class="w-4 h-4" /></button>
                     </div>
                     <div class="flex-1 flex flex-col items-center justify-center text-center space-y-4 py-4">
                         <div class="w-full bg-white/5 border border-dashed border-white/10 rounded-xl p-4 flex items-center justify-between group hover:border-blue-500/50 hover:bg-blue-500/5 transition-all cursor-pointer">
@@ -447,8 +438,8 @@ const handlePortfolioUpload = () => {
                                     <div class="text-xs text-slate-500">2.4 MB • 2024.02.01 업데이트</div>
                                 </div>
                             </div>
-                            <button class="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center text-slate-400 hover:bg-blue-500 hover:text-white transition-all">
-                                <Briefcase class="w-4 h-4" /> <!-- Using Briefcase as download icon placeholder since Download icon might not be imported. Will check imports. -->
+                            <button @click="alert('포트폴리오 다운로드 시작')" class="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center text-slate-400 hover:bg-blue-500 hover:text-white transition-all">
+                                <Download class="w-4 h-4" />
                             </button>
                         </div>
                         

--- a/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
@@ -140,6 +140,9 @@ const onFileChange = (event: Event) => {
     const file = target.files?.[0];
     
     if (file) {
+        if (profile.value.portfolio.fileUrl) {
+            URL.revokeObjectURL(profile.value.portfolio.fileUrl);
+        }
         // Create object URL for the file
         const fileUrl = URL.createObjectURL(file);
         
@@ -155,9 +158,12 @@ const onFileChange = (event: Event) => {
 };
 
 const downloadPortfolio = () => {
-    if (profile.value.portfolio.fileUrl) {
+    const fileUrl = profile.value.portfolio.fileUrl;
+    const isValid = fileUrl && typeof fileUrl === 'string' && fileUrl.trim() !== '' && fileUrl !== '#';
+
+    if (isValid) {
         const link = document.createElement('a');
-        link.href = profile.value.portfolio.fileUrl;
+        link.href = fileUrl!;
         link.download = profile.value.portfolio.fileName || 'portfolio.pdf';
         document.body.appendChild(link);
         link.click();

--- a/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
@@ -19,8 +19,8 @@ import {
   Upload,
   Download,
 } from 'lucide-vue-next';
-import { useAuthStore } from '@/stores/authStore.ts';
-import { getFreelancerProfile, type FreelancerProfileDashboard } from '@/api/MyPage/freelancerApi.ts';
+import { useAuthStore } from '@/stores/authStore';
+import { getFreelancerProfile, type FreelancerProfileDashboard } from '@/api/MyPage/freelancerApi';
 import ResumeManagementPage from './components/ResumeManagementPage.vue';
 import EvaluationListPage from './components/EvaluationListPage.vue';
 import AccountManagementPage from './components/AccountManagementPage.vue';
@@ -76,7 +76,12 @@ const profile = ref<FreelancerProfileDashboard>({
     statChat: 0,
     statContract: 0,
     statInteresting: 0,
-    statCompleted: 0
+    statCompleted: 0,
+    portfolio: {
+        fileUrl: null,
+        fileName: '',
+        lastUpdated: ''
+    }
 });
 
 const handleProfileUpdate = (updatedData: FreelancerProfileDashboard) => {
@@ -124,9 +129,42 @@ const getGradeColor = (grade: string) => {
     }
 };
 
+const fileInput = ref<HTMLInputElement | null>(null);
+
 const handlePortfolioUpload = () => {
-    alert('포트폴리오 업로드 완료!');
-    isPortfolioOpen.value = false;
+    fileInput.value?.click();
+};
+
+const onFileChange = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    const file = target.files?.[0];
+    
+    if (file) {
+        // Create object URL for the file
+        const fileUrl = URL.createObjectURL(file);
+        
+        // Update profile (Mock update)
+        profile.value.portfolio = {
+            fileUrl: fileUrl,
+            fileName: file.name,
+            lastUpdated: new Date().toLocaleDateString()
+        };
+        
+        alert('포트폴리오가 업로드되었습니다.');
+    }
+};
+
+const downloadPortfolio = () => {
+    if (profile.value.portfolio.fileUrl) {
+        const link = document.createElement('a');
+        link.href = profile.value.portfolio.fileUrl;
+        link.download = profile.value.portfolio.fileName || 'portfolio.pdf';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+    } else {
+        alert('다운로드할 포트폴리오가 없습니다.');
+    }
 };
 </script>
 
@@ -425,20 +463,27 @@ const handlePortfolioUpload = () => {
                 <div class="bg-[#1e293b]/50 rounded-2xl p-6 border border-white/5 backdrop-blur-sm h-full flex flex-col">
                     <div class="flex justify-between items-center mb-6">
                         <h4 class="font-bold text-base text-white">포트폴리오</h4>
+                        <input 
+                            type="file" 
+                            ref="fileInput" 
+                            class="hidden" 
+                            accept=".pdf"
+                            @change="onFileChange"
+                        />
                         <button @click="handlePortfolioUpload" class="text-slate-500 hover:text-white transition-colors"><Upload class="w-4 h-4" /></button>
                     </div>
                     <div class="flex-1 flex flex-col items-center justify-center text-center space-y-4 py-4">
                         <div class="w-full bg-white/5 border border-dashed border-white/10 rounded-xl p-4 flex items-center justify-between group hover:border-blue-500/50 hover:bg-blue-500/5 transition-all cursor-pointer">
-                            <div class="flex items-center gap-3">
+                            <div class="flex items-center gap-3" @click="downloadPortfolio">
                                 <div class="w-10 h-10 bg-red-400/20 rounded-lg flex items-center justify-center text-red-400">
                                     <FileText class="w-5 h-5" />
                                 </div>
                                 <div class="text-left">
-                                    <div class="text-sm font-bold text-white group-hover:text-blue-400 transition-colors">Portfolio_2024.pdf</div>
-                                    <div class="text-xs text-slate-500">2.4 MB • 2024.02.01 업데이트</div>
+                                    <div class="text-sm font-bold text-white group-hover:text-blue-400 transition-colors">{{ profile.portfolio?.fileName || '포트폴리오 없음' }}</div>
+                                    <div class="text-xs text-slate-500">{{ profile.portfolio?.lastUpdated }} 업데이트</div>
                                 </div>
                             </div>
-                            <button @click="alert('포트폴리오 다운로드 시작')" class="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center text-slate-400 hover:bg-blue-500 hover:text-white transition-all">
+                            <button @click.stop="downloadPortfolio" class="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center text-slate-400 hover:bg-blue-500 hover:text-white transition-all">
                                 <Download class="w-4 h-4" />
                             </button>
                         </div>
@@ -471,6 +516,7 @@ const handlePortfolioUpload = () => {
 
         <EvaluationListPage
             v-else-if="activeTab === 'evaluation'"
+            :profile="profile"
             @back="activeTab = 'dashboard'"
         />
 

--- a/freebridgefe/src/views/freelancer/MyPage/components/AccountManagementPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/AccountManagementPage.vue
@@ -8,13 +8,10 @@ import {
     Phone,
     Lock,
     Bell,
-    Shield,
-    Save,
     Eye,
     EyeOff,
-    Smartphone,
     Key,
-    AlertCircle
+    Save
 } from 'lucide-vue-next';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -53,12 +50,12 @@ const showPasswords = ref({
 
 const notifications = ref({
     email: true,
-    sms: false,
+
     push: true,
     marketing: false,
 });
 
-const twoFactorEnabled = ref(false);
+
 
 const handleSaveAccountInfo = async () => {
     if (!isProfileVerified.value) {
@@ -372,7 +369,7 @@ const handleChangePassword = async () => {
                  <div
                     v-for="(item, key) in {
                         email: { label: '이메일 알림', desc: '프로젝트 제안 및 중요 공지를 이메일로 받습니다' },
-                        sms: { label: 'SMS 알림', desc: '긴급 알림을 문자로 받습니다' },
+
                         push: { label: '푸시 알림', desc: '브라우저 푸시 알림을 받습니다' },
                         marketing: { label: '마케팅 정보 수신', desc: '프로모션 및 이벤트 정보를 받습니다' }
                     }"
@@ -397,54 +394,7 @@ const handleChangePassword = async () => {
             </div>
         </div>
 
-        <!-- Security Settings -->
-        <div
-            class="bg-white/5 rounded-2xl border border-white/10 p-8"
-            v-motion
-            :initial="{ opacity: 0, y: 20 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: 300 } }"
-        >
-            <h2 class="text-lg font-bold text-white mb-6 flex items-center gap-2">
-                <Shield class="w-5 h-5 text-green-400" />
-                보안 설정
-            </h2>
 
-             <div class="space-y-4">
-                <div class="flex items-center justify-between p-4 bg-white/5 rounded-lg border border-white/5">
-                    <div class="flex-1">
-                        <div class="flex items-center gap-2 mb-1">
-                            <Smartphone class="w-4 h-4 text-green-400" />
-                            <h3 class="font-semibold text-white text-sm">2단계 인증 (2FA)</h3>
-                        </div>
-                        <p class="text-xs text-slate-400">로그인 시 추가 보안 인증을 요구합니다</p>
-                    </div>
-                    <button
-                        @click="twoFactorEnabled = !twoFactorEnabled"
-                        class="relative w-12 h-6 rounded-full transition-colors"
-                        :class="twoFactorEnabled ? 'bg-green-500' : 'bg-slate-600'"
-                    >
-                        <div
-                            class="absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform"
-                            :class="twoFactorEnabled ? 'translate-x-6' : ''"
-                        />
-                    </button>
-                </div>
-
-                <div class="p-4 bg-orange-500/10 border border-orange-500/20 rounded-lg">
-                    <div class="flex items-start gap-3">
-                        <AlertCircle class="w-5 h-5 text-orange-400 flex-shrink-0 mt-0.5" />
-                        <div>
-                            <h3 class="font-semibold text-orange-300 text-sm mb-1">계정 보안 팁</h3>
-                            <ul class="text-xs text-orange-200/80 space-y-1">
-                                <li>• 정기적으로 비밀번호를 변경하세요</li>
-                                <li>• 다른 사이트와 동일한 비밀번호를 사용하지 마세요</li>
-                                <li>• 2단계 인증을 활성화하여 계정을 보호하세요</li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
         </div>
     </div>
   </div>

--- a/freebridgefe/src/views/freelancer/MyPage/components/AccountManagementPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/AccountManagementPage.vue
@@ -11,10 +11,13 @@ import {
     Eye,
     EyeOff,
     Key,
-    Save
+    Save,
+    ShieldCheck,
+    Loader2,
+    CheckCircle2,
+    AlertCircle
 } from 'lucide-vue-next';
 import { useAuthStore } from '@/stores/authStore';
-
 import { updateAccountInfo, changePassword } from '@/api/MyPage/accountApi';
 
 const emit = defineEmits<{
@@ -50,34 +53,12 @@ const showPasswords = ref({
 
 const notifications = ref({
     email: true,
-
     push: true,
     marketing: false,
 });
 
-
-
-const handleSaveAccountInfo = async () => {
-    if (!isProfileVerified.value) {
-        alert('비밀번호 확인 후 내 정보를 수정할 수 있습니다.');
-        return;
-    }
-    try {
-        const success = await updateAccountInfo(accountInfo.value);
-        if (success) {
-            alert('계정 정보가 저장되었습니다.');
-            // authStore 업데이트 로직이 필요하다면 추가
-            if (currentUser) {
-                currentUser.name = accountInfo.value.name;
-                // currentUser.phone = accountInfo.value.phone; // 타입에 phone이 있다면
-            }
-        } else {
-            alert('저장에 실패했습니다.');
-        }
-    } catch (e) {
-        alert('오류가 발생했습니다.');
-    }
-};
+const isSavingInfo = ref(false);
+const isChangingPassword = ref(false);
 
 const handleVerifyIdentity = async () => {
     verificationError.value = '';
@@ -88,15 +69,19 @@ const handleVerifyIdentity = async () => {
         return;
     }
 
+    // For demo purposes, if no password in store (guest), allow any non-empty password or match specific mock
     if (!currentPassword) {
-        verificationError.value = '로그인한 계정의 비밀번호 정보를 찾을 수 없습니다. 다시 로그인해 주세요.';
-        isProfileVerified.value = false;
-        return;
+         // Fallback for guest mode or testing without full auth
+         isVerifying.value = true;
+         await new Promise((resolve) => setTimeout(resolve, 600));
+         isProfileVerified.value = true;
+         isVerifying.value = false;
+         return;
     }
 
     try {
         isVerifying.value = true;
-        await new Promise((resolve) => setTimeout(resolve, 250));
+        await new Promise((resolve) => setTimeout(resolve, 600));
 
         if (verificationPassword.value !== currentPassword) {
             verificationError.value = '비밀번호가 올바르지 않습니다.';
@@ -111,10 +96,28 @@ const handleVerifyIdentity = async () => {
     }
 };
 
-const resetProfileVerification = () => {
-    isProfileVerified.value = false;
-    verificationPassword.value = '';
-    verificationError.value = '';
+const handleSaveAccountInfo = async () => {
+    if (!isProfileVerified.value) {
+        alert('비밀번호 확인 후 내 정보를 수정할 수 있습니다.');
+        return;
+    }
+    isSavingInfo.value = true;
+    try {
+        await new Promise((resolve) => setTimeout(resolve, 800)); // Simulate delay
+        const success = await updateAccountInfo(accountInfo.value);
+        if (success) {
+            alert('계정 정보가 저장되었습니다.');
+            if (currentUser) {
+                currentUser.name = accountInfo.value.name;
+            }
+        } else {
+            alert('저장에 실패했습니다.');
+        }
+    } catch (e) {
+        alert('오류가 발생했습니다.');
+    } finally {
+        isSavingInfo.value = false;
+    }
 };
 
 const handleChangePassword = async () => {
@@ -127,7 +130,9 @@ const handleChangePassword = async () => {
         return;
     }
     
+    isChangingPassword.value = true;
     try {
+        await new Promise((resolve) => setTimeout(resolve, 800)); // Simulate delay
         const success = await changePassword({
             current: passwordData.value.currentPassword,
             new: passwordData.value.newPassword,
@@ -142,259 +147,272 @@ const handleChangePassword = async () => {
         }
     } catch (e) {
         alert('오류가 발생했습니다.');
+    } finally {
+        isChangingPassword.value = false;
     }
+};
+
+const resetProfileVerification = () => {
+    isProfileVerified.value = false;
+    verificationPassword.value = '';
+    verificationError.value = '';
 };
 </script>
 
 <template>
-  <div class="max-w-4xl mx-auto px-4 md:px-8 py-8 font-sans text-white">
+  <div class="max-w-5xl mx-auto px-4 md:px-8 py-10 font-sans text-white">
     <!-- Header -->
-    <div class="flex items-center gap-4 mb-8">
+    <div class="flex items-center gap-4 mb-10">
         <button
             @click="$emit('back')"
-            class="p-2 hover:bg-white/5 rounded-lg transition-colors"
-            v-motion
-            :hover="{ scale: 1.1 }"
-            :tap="{ scale: 0.9 }"
+            class="p-2 hover:bg-white/5 rounded-full transition-colors"
         >
-            <ArrowLeft class="w-5 h-5 text-white/60" />
+            <ArrowLeft class="w-6 h-6 text-white/80" />
         </button>
         <div>
-            <h1 class="text-2xl font-bold text-white">내 계정 관리</h1>
-            <p class="text-sm text-slate-400 mt-1">계정 정보 및 보안 설정을 관리하세요</p>
+            <h1 class="text-3xl font-bold text-white tracking-tight">내 계정 관리</h1>
+            <p class="text-base text-slate-400 mt-1">계정 정보 및 보안 설정을 안전하게 관리하세요.</p>
         </div>
     </div>
 
-    <div class="space-y-6">
-        <div
-            v-if="!isProfileVerified"
-            class="bg-white/5 rounded-2xl border border-white/10 p-8"
-            v-motion
-            :initial="{ opacity: 0, y: 20 }"
-            :enter="{ opacity: 1, y: 0 }"
-        >
-            <div class="flex items-center justify-between mb-6">
-                <h2 class="text-lg font-bold text-white flex items-center gap-2">
-                    <Lock class="w-5 h-5 text-blue-400" />
-                    비밀번호 확인
-                </h2>
+    <!-- Identity Verification (Shown when not verified) -->
+    <div v-if="!isProfileVerified" class="max-w-md mx-auto mt-20" v-motion :initial="{ opacity: 0, scale: 0.95 }" :enter="{ opacity: 1, scale: 1 }">
+        <div class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-md text-center shadow-2xl">
+            <div class="w-20 h-20 bg-blue-500/10 rounded-full flex items-center justify-center mx-auto mb-6">
+                <ShieldCheck class="w-10 h-10 text-blue-400" />
             </div>
-            <p class="text-sm text-slate-400 mb-4">
-                보안을 위해 비밀번호를 한 번 더 입력해 주세요.
+            <h2 class="text-2xl font-bold text-white mb-2">본인 확인</h2>
+            <p class="text-slate-400 mb-8 text-sm leading-relaxed">
+                개인정보 보호를 위해 비밀번호를 입력해 주세요.<br>
+                인증 후 정보를 수정할 수 있습니다.
             </p>
-            <div class="flex items-center gap-3 bg-white/5 border border-white/10 rounded-lg px-4 py-3">
-                <Key class="w-4 h-4 text-slate-400" />
-                <input
-                    type="password"
-                    v-model="verificationPassword"
-                    class="bg-transparent border-none outline-none w-full text-white text-sm"
-                    placeholder="비밀번호를 입력하세요"
-                    @keyup.enter="handleVerifyIdentity"
-                />
-            </div>
-            <p v-if="verificationError" class="text-sm text-red-400 mt-2">{{ verificationError }}</p>
-            <button
-                @click="handleVerifyIdentity"
-                :disabled="isVerifying"
-                class="mt-4 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-bold transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
-            >
-                {{ isVerifying ? '확인 중...' : '확인' }}
-            </button>
-        </div>
 
-        <div v-else class="flex justify-end">
-            <button
-                @click="resetProfileVerification"
-                class="text-xs text-slate-400 hover:text-white transition-colors"
-            >
-                다시 인증하기
-            </button>
-        </div>
-
-        <div v-if="isProfileVerified" class="space-y-6">
-        <!-- Account Information -->
-        <div
-            class="bg-white/5 rounded-2xl border border-white/10 p-8"
-            v-motion
-            :initial="{ opacity: 0, y: 20 }"
-            :enter="{ opacity: 1, y: 0 }"
-        >
-            <div class="flex items-center justify-between mb-6">
-                <h2 class="text-lg font-bold text-white flex items-center gap-2">
-                    <User class="w-5 h-5 text-blue-400" />
-                    기본 정보
-                </h2>
-                <button
-                    @click="handleSaveAccountInfo"
-                    class="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-bold transition-colors flex items-center gap-2"
-                >
-                    <Save class="w-4 h-4" />
-                    저장
-                </button>
-            </div>
-
-            <div class="space-y-4">
-                <div>
-                    <label class="text-xs text-slate-500 mb-2 block">이름</label>
-                    <div class="flex items-center gap-3 bg-white/5 border border-white/10 rounded-lg px-4 py-3">
-                        <User class="w-4 h-4 text-slate-400" />
+            <div class="space-y-4 text-left">
+                <div class="space-y-2">
+                    <label class="text-xs text-slate-500 font-bold ml-1">비밀번호</label>
+                    <div class="relative">
+                        <Key class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
                         <input
-                            type="text"
-                            v-model="accountInfo.name"
-                            class="bg-transparent border-none outline-none w-full text-white text-sm"
+                            type="password"
+                            v-model="verificationPassword"
+                            class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
+                            placeholder="비밀번호 입력"
+                            @keyup.enter="handleVerifyIdentity"
                         />
                     </div>
                 </div>
-
-                <div>
-                    <label class="text-xs text-slate-500 mb-2 block">이메일</label>
-                    <div class="flex items-center gap-3 bg-white/5 border border-white/10 rounded-lg px-4 py-3">
-                        <Mail class="w-4 h-4 text-slate-400" />
-                        <input
-                            type="email"
-                            v-model="accountInfo.email"
-                            class="bg-transparent border-none outline-none w-full text-white text-sm"
-                        />
-                    </div>
-                </div>
-
-                <div>
-                    <label class="text-xs text-slate-500 mb-2 block">휴대폰 번호</label>
-                    <div class="flex items-center gap-3 bg-white/5 border border-white/10 rounded-lg px-4 py-3">
-                        <Phone class="w-4 h-4 text-slate-400" />
-                        <input
-                            type="tel"
-                            v-model="accountInfo.phone"
-                            class="bg-transparent border-none outline-none w-full text-white text-sm"
-                        />
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Password Change -->
-        <div
-            class="bg-white/5 rounded-2xl border border-white/10 p-8"
-            v-motion
-            :initial="{ opacity: 0, y: 20 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: 100 } }"
-        >
-            <div class="flex items-center justify-between mb-6">
-                <h2 class="text-lg font-bold text-white flex items-center gap-2">
-                    <Lock class="w-5 h-5 text-purple-400" />
-                    비밀번호 변경
-                </h2>
-            </div>
-
-            <div class="space-y-4">
-                <div>
-                    <label class="text-xs text-slate-500 mb-2 block">현재 비밀번호</label>
-                    <div class="flex items-center gap-3 bg-white/5 border border-white/10 rounded-lg px-4 py-3">
-                        <Key class="w-4 h-4 text-slate-400" />
-                        <input
-                            :type="showPasswords.current ? 'text' : 'password'"
-                            v-model="passwordData.currentPassword"
-                            class="bg-transparent border-none outline-none w-full text-white text-sm"
-                            placeholder="현재 비밀번호를 입력하세요"
-                        />
-                        <button
-                            @click="showPasswords.current = !showPasswords.current"
-                            class="text-slate-400 hover:text-white transition-colors"
-                        >
-                            <component :is="showPasswords.current ? EyeOff : Eye" class="w-4 h-4" />
-                        </button>
-                    </div>
-                </div>
-
-                <div>
-                    <label class="text-xs text-slate-500 mb-2 block">새 비밀번호</label>
-                    <div class="flex items-center gap-3 bg-white/5 border border-white/10 rounded-lg px-4 py-3">
-                        <Lock class="w-4 h-4 text-slate-400" />
-                        <input
-                             :type="showPasswords.new ? 'text' : 'password'"
-                            v-model="passwordData.newPassword"
-                            class="bg-transparent border-none outline-none w-full text-white text-sm"
-                            placeholder="새 비밀번호 (최소 8자)"
-                        />
-                        <button
-                            @click="showPasswords.new = !showPasswords.new"
-                            class="text-slate-400 hover:text-white transition-colors"
-                        >
-                             <component :is="showPasswords.new ? EyeOff : Eye" class="w-4 h-4" />
-                        </button>
-                    </div>
-                </div>
-
-                <div>
-                    <label class="text-xs text-slate-500 mb-2 block">새 비밀번호 확인</label>
-                    <div class="flex items-center gap-3 bg-white/5 border border-white/10 rounded-lg px-4 py-3">
-                        <Lock class="w-4 h-4 text-slate-400" />
-                        <input
-                             :type="showPasswords.confirm ? 'text' : 'password'"
-                            v-model="passwordData.confirmPassword"
-                            class="bg-transparent border-none outline-none w-full text-white text-sm"
-                            placeholder="새 비밀번호를 다시 입력하세요"
-                        />
-                        <button
-                            @click="showPasswords.confirm = !showPasswords.confirm"
-                            class="text-slate-400 hover:text-white transition-colors"
-                        >
-                             <component :is="showPasswords.confirm ? EyeOff : Eye" class="w-4 h-4" />
-                        </button>
-                    </div>
-                </div>
+                
+                <p v-if="verificationError" class="text-xs text-red-400 flex items-center gap-1">
+                    <AlertCircle class="w-3.5 h-3.5" />
+                    {{ verificationError }}
+                </p>
 
                 <button
-                    @click="handleChangePassword"
-                    class="w-full py-3 bg-purple-600 hover:bg-purple-500 text-white rounded-lg font-bold transition-colors"
+                    @click="handleVerifyIdentity"
+                    :disabled="isVerifying"
+                    class="w-full py-3.5 bg-blue-600 hover:bg-blue-500 disabled:bg-blue-600/50 text-white rounded-xl font-bold transition-all flex items-center justify-center gap-2 shadow-lg shadow-blue-500/20 mt-4"
                 >
-                    비밀번호 변경
+                    <Loader2 v-if="isVerifying" class="w-4 h-4 animate-spin" />
+                    <span>{{ isVerifying ? '확인 중...' : '인증하기' }}</span>
                 </button>
             </div>
         </div>
+    </div>
 
-        <!-- Notification Settings -->
-        <div
-            class="bg-white/5 rounded-2xl border border-white/10 p-8"
-            v-motion
-            :initial="{ opacity: 0, y: 20 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: 200 } }"
-        >
-            <h2 class="text-lg font-bold text-white mb-6 flex items-center gap-2">
-                <Bell class="w-5 h-5 text-yellow-400" />
-                알림 설정
-            </h2>
-
-            <div class="space-y-4">
-                 <div
-                    v-for="(item, key) in {
-                        email: { label: '이메일 알림', desc: '프로젝트 제안 및 중요 공지를 이메일로 받습니다' },
-
-                        push: { label: '푸시 알림', desc: '브라우저 푸시 알림을 받습니다' },
-                        marketing: { label: '마케팅 정보 수신', desc: '프로모션 및 이벤트 정보를 받습니다' }
-                    }"
-                    :key="key"
-                    class="flex items-center justify-between p-4 bg-white/5 rounded-lg border border-white/5 hover:bg-white/10 transition-colors"
-                >
-                    <div class="flex-1">
-                        <h3 class="font-semibold text-white text-sm mb-1">{{ item.label }}</h3>
-                        <p class="text-xs text-slate-400">{{ item.desc }}</p>
-                    </div>
-                    <button
-                        @click="notifications[key as keyof typeof notifications] = !notifications[key as keyof typeof notifications]"
-                        class="relative w-12 h-6 rounded-full transition-colors"
-                        :class="notifications[key as keyof typeof notifications] ? 'bg-blue-500' : 'bg-slate-600'"
+    <!-- Account Management Content (Shown when verified) -->
+    <div v-else class="grid grid-cols-1 lg:grid-cols-12 gap-8 animate-fade-in-up">
+        
+        <!-- Left Column: Basic Info -->
+        <div class="lg:col-span-7 space-y-8">
+            <!-- Basic Info Card -->
+            <section class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-sm relative overflow-hidden">
+                <div class="flex items-center justify-between mb-8">
+                    <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                        <div class="p-2 bg-blue-500/10 rounded-lg">
+                            <User class="w-5 h-5 text-blue-400" />
+                        </div>
+                        기본 정보
+                    </h2>
+                     <button
+                        @click="handleSaveAccountInfo"
+                        :disabled="isSavingInfo"
+                        class="px-5 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-xl text-sm font-bold transition-all flex items-center gap-2 shadow-lg shadow-blue-500/20"
                     >
-                        <div
-                            class="absolute top-1 left-1 w-4 h-4 bg-white rounded-full transition-transform"
-                            :class="notifications[key as keyof typeof notifications] ? 'translate-x-6' : ''"
-                        />
+                        <Loader2 v-if="isSavingInfo" class="w-3.5 h-3.5 animate-spin" />
+                        <Save v-else class="w-3.5 h-3.5" />
+                        저장
                     </button>
                 </div>
-            </div>
+
+                <div class="space-y-5">
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">이름</label>
+                        <div class="relative">
+                            <User class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
+                            <input
+                                type="text"
+                                v-model="accountInfo.name"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
+                            />
+                        </div>
+                    </div>
+
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">이메일</label>
+                        <div class="relative">
+                            <Mail class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
+                            <input
+                                type="email"
+                                v-model="accountInfo.email"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
+                            />
+                        </div>
+                    </div>
+
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">휴대폰 번호</label>
+                        <div class="relative">
+                             <Phone class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
+                            <input
+                                type="tel"
+                                v-model="accountInfo.phone"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+             <!-- Notification Settings -->
+            <section class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-sm">
+                <h2 class="text-xl font-bold text-white mb-6 flex items-center gap-2">
+                    <div class="p-2 bg-yellow-500/10 rounded-lg">
+                        <Bell class="w-5 h-5 text-yellow-400" />
+                    </div>
+                    알림 설정
+                </h2>
+
+                <div class="space-y-4">
+                     <div
+                        v-for="(item, key) in {
+                            email: { label: '이메일 알림', desc: '프로젝트 제안 및 중요 공지를 이메일로 받습니다' },
+                            push: { label: '푸시 알림', desc: '브라우저 푸시 알림을 받습니다' },
+                            marketing: { label: '마케팅 정보 수신', desc: '프로모션 및 이벤트 정보를 받습니다' }
+                        }"
+                        :key="key"
+                        class="flex items-center justify-between p-4 bg-[#1e293b]/30 rounded-2xl border border-white/5 hover:bg-[#1e293b]/50 transition-colors"
+                    >
+                        <div class="flex-1 pr-4">
+                            <h3 class="font-bold text-white text-sm mb-1">{{ item.label }}</h3>
+                            <p class="text-xs text-slate-400">{{ item.desc }}</p>
+                        </div>
+                        <button
+                            @click="notifications[key as keyof typeof notifications] = !notifications[key as keyof typeof notifications]"
+                            class="relative w-12 h-7 rounded-full transition-colors duration-300 focus:outline-none"
+                            :class="notifications[key as keyof typeof notifications] ? 'bg-blue-500' : 'bg-slate-700'"
+                        >
+                            <div
+                                class="absolute top-1 left-1 w-5 h-5 bg-white rounded-full transition-transform duration-300 shadow-md"
+                                :class="notifications[key as keyof typeof notifications] ? 'translate-x-5' : ''"
+                            />
+                        </button>
+                    </div>
+                </div>
+            </section>
         </div>
 
+        <!-- Right Column: Password & Security -->
+        <div class="lg:col-span-5 space-y-8">
+            <!-- Password Change -->
+            <section class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-sm h-full flex flex-col">
+                <div class="flex items-center justify-between mb-8">
+                    <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                        <div class="p-2 bg-purple-500/10 rounded-lg">
+                            <Lock class="w-5 h-5 text-purple-400" />
+                        </div>
+                        비밀번호 변경
+                    </h2>
+                </div>
 
+                <div class="space-y-5 flex-1">
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">현재 비밀번호</label>
+                        <div class="relative">
+                            <Key class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
+                            <input
+                                :type="showPasswords.current ? 'text' : 'password'"
+                                v-model="passwordData.currentPassword"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-10 py-3 text-white text-sm outline-none focus:border-purple-500/50 focus:bg-[#1e293b] transition-all"
+                                placeholder="현재 비밀번호 입력"
+                            />
+                            <button
+                                @click="showPasswords.current = !showPasswords.current"
+                                class="absolute right-3 top-3 text-slate-400 hover:text-white transition-colors"
+                            >
+                                <component :is="showPasswords.current ? EyeOff : Eye" class="w-4 h-4" />
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="w-full h-px bg-white/5 my-2"></div>
+
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">새 비밀번호</label>
+                        <div class="relative">
+                            <Lock class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
+                            <input
+                                :type="showPasswords.new ? 'text' : 'password'"
+                                v-model="passwordData.newPassword"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-10 py-3 text-white text-sm outline-none focus:border-purple-500/50 focus:bg-[#1e293b] transition-all"
+                                placeholder="새 비밀번호 (8자 이상)"
+                            />
+                            <button
+                                @click="showPasswords.new = !showPasswords.new"
+                                class="absolute right-3 top-3 text-slate-400 hover:text-white transition-colors"
+                            >
+                                <component :is="showPasswords.new ? EyeOff : Eye" class="w-4 h-4" />
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">새 비밀번호 확인</label>
+                        <div class="relative">
+                            <CheckCircle2 class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
+                            <input
+                                :type="showPasswords.confirm ? 'text' : 'password'"
+                                v-model="passwordData.confirmPassword"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-10 py-3 text-white text-sm outline-none focus:border-purple-500/50 focus:bg-[#1e293b] transition-all"
+                                placeholder="새 비밀번호 다시 입력"
+                            />
+                            <button
+                                @click="showPasswords.confirm = !showPasswords.confirm"
+                                class="absolute right-3 top-3 text-slate-400 hover:text-white transition-colors"
+                            >
+                                <component :is="showPasswords.confirm ? EyeOff : Eye" class="w-4 h-4" />
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="pt-6 mt-auto">
+                        <button
+                            @click="handleChangePassword"
+                            :disabled="isChangingPassword"
+                            class="w-full py-4 bg-purple-600 hover:bg-purple-500 text-white rounded-xl font-bold transition-all shadow-lg shadow-purple-500/20 flex items-center justify-center gap-2"
+                        >
+                            <Loader2 v-if="isChangingPassword" class="w-4 h-4 animate-spin" />
+                            {{ isChangingPassword ? '변경 중...' : '비밀번호 변경하기' }}
+                        </button>
+                    </div>
+                </div>
+            </section>
+
+             <button
+                @click="resetProfileVerification"
+                class="w-full py-3 bg-white/5 hover:bg-white/10 border border-white/10 rounded-xl text-slate-400 hover:text-white text-sm font-bold transition-all"
+            >
+                인증 상태 초기화 (로그아웃 효과)
+            </button>
         </div>
     </div>
   </div>

--- a/freebridgefe/src/views/freelancer/MyPage/components/EvaluationListPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/EvaluationListPage.vue
@@ -8,10 +8,16 @@ import {
     Search,
     MessageSquare,
     Calendar,
-    Briefcase
+    Briefcase,
+    Sparkles
 } from 'lucide-vue-next';
 import { getEvaluations, getRejectionFeedbacks, type Evaluation, type RejectionFeedback } from '@/api/MyPage/evaluationApi';
 import { useAuthStore } from '@/stores/authStore';
+import type { FreelancerProfileDashboard } from '@/api/MyPage/freelancerApi';
+
+const props = defineProps<{
+    profile?: FreelancerProfileDashboard; // Optional to allow independent use if needed, but primarily passed from parent
+}>();
 
 const emit = defineEmits<{
     (e: 'back'): void;
@@ -90,9 +96,10 @@ const filteredRejections = computed(() => {
     return result;
 });
 
-// Computed: 평균 평점
+// Computed: 평균 평점 (from props if available, else from list)
 const averageScore = computed(() => {
-    if (evaluations.value.length === 0) return 0;
+    if (props.profile) return props.profile.averageRating.toFixed(1);
+    if (evaluations.value.length === 0) return '0.0';
     const total = evaluations.value.reduce((sum, e) => sum + e.score, 0);
     return (total / evaluations.value.length).toFixed(1);
 });
@@ -101,29 +108,72 @@ const averageScore = computed(() => {
 <template>
   <div class="max-w-5xl mx-auto px-4 md:px-8 py-8 font-sans text-white">
     <!-- Header -->
-    <div class="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-6">
-        <div class="flex items-center gap-4">
-            <button
-                @click="$emit('back')"
-                class="p-2 hover:bg-white/5 rounded-lg transition-colors"
-            >
-                <ArrowLeft class="w-5 h-5 text-white/60" />
-            </button>
-            <div>
-                <h1 class="text-2xl font-bold text-white">받은 평가 관리</h1>
-                <p class="text-sm text-slate-400 mt-1">프로젝트 완료 후 받은 고용주의 평가를 확인하세요.</p>
+    <div class="flex items-center gap-4 mb-8">
+        <button
+            @click="$emit('back')"
+            class="p-2 hover:bg-white/5 rounded-lg transition-colors"
+        >
+            <ArrowLeft class="w-5 h-5 text-white/60" />
+        </button>
+        <div>
+            <h1 class="text-2xl font-bold text-white">받은 평가 관리</h1>
+            <p class="text-sm text-slate-400 mt-1">프로젝트 완료 후 받은 고용주의 평가를 확인하세요.</p>
+        </div>
+    </div>
+
+    <!-- Summary Section (New) -->
+    <div v-if="props.profile" class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10 animate-fade-in-up">
+        <!-- Total Average -->
+        <div class="bg-white/5 border border-white/10 rounded-2xl p-6 flex flex-col items-center justify-center gap-2">
+            <div class="text-sm text-slate-400 font-bold">전체 평균 평점</div>
+            <div class="flex items-center gap-2">
+                <Star class="w-8 h-8 text-yellow-400 fill-yellow-400" />
+                <span class="text-4xl font-bold text-white">{{ averageScore }}</span>
+                <span class="text-sm text-slate-500 self-end mb-1">/ 5.0</span>
+            </div>
+            <div class="text-xs text-slate-500 mt-2">총 {{ evaluations.length }}건의 평가 기준</div>
+        </div>
+
+        <!-- Detailed Stats -->
+        <div class="bg-white/5 border border-white/10 rounded-2xl p-6 flex flex-col justify-center">
+            <h3 class="text-sm font-bold text-slate-400 mb-4">항목별 평점 분석</h3>
+            <div class="space-y-4">
+                <!-- Professionalism Average -->
+                <div class="space-y-1">
+                    <div class="flex justify-between text-xs mb-1">
+                        <span class="text-slate-300">전문성 (프로그래밍/프레임워크)</span>
+                        <span class="font-bold text-blue-400">{{ props.profile?.expertise ? ((props.profile.expertise.programming + props.profile.expertise.framework + props.profile.expertise.problemSolving) / 3).toFixed(1) : '0.0' }}</span>
+                    </div>
+                    <div class="h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                        <div class="h-full bg-blue-500" :style="{ width: props.profile?.expertise ? `${(((props.profile.expertise.programming + props.profile.expertise.framework + props.profile.expertise.problemSolving) / 3) / 5) * 100}%` : '0%' }"></div>
+                    </div>
+                </div>
+                 <!-- Collaboration Average -->
+                 <div class="space-y-1">
+                    <div class="flex justify-between text-xs mb-1">
+                        <span class="text-slate-300">협업 능력 (소통/일정준수)</span>
+                        <span class="font-bold text-purple-400">{{ props.profile?.collaboration ? ((props.profile.collaboration.communication + props.profile.collaboration.scheduleAdherence + props.profile.collaboration.dispute) / 3).toFixed(1) : '0.0' }}</span>
+                    </div>
+                    <div class="h-1.5 bg-slate-700 rounded-full overflow-hidden">
+                        <div class="h-full bg-purple-500" :style="{ width: props.profile?.collaboration ? `${(((props.profile.collaboration.communication + props.profile.collaboration.scheduleAdherence + props.profile.collaboration.dispute) / 3) / 5) * 100}%` : '0%' }"></div>
+                    </div>
+                </div>
             </div>
         </div>
 
-        <!-- Summary Card (Optional) -->
-        <div class="bg-white/5 border border-white/10 rounded-xl px-4 py-2 flex items-center gap-3">
-             <div class="flex items-center gap-1">
-                <Star class="w-5 h-5 text-yellow-400 fill-yellow-400" />
-                <span class="text-lg font-bold text-white">{{ averageScore }}</span>
-                <span class="text-sm text-slate-500">/ 5.0</span>
-             </div>
-             <div class="w-px h-8 bg-white/10 mx-2"></div>
-             <span class="text-sm text-slate-400">총 {{ evaluations.length }}건의 평가</span>
+        <!-- AI Summary -->
+        <div class="bg-gradient-to-br from-indigo-900/40 to-purple-900/40 border border-white/10 rounded-2xl p-6 relative overflow-hidden group">
+            <div class="absolute top-0 right-0 p-4 opacity-50">
+                <Sparkles class="w-12 h-12 text-white/5" />
+            </div>
+            <h3 class="text-sm font-bold text-indigo-300 mb-3 flex items-center gap-2">
+                <Sparkles class="w-4 h-4" />
+                AI 분석 요약
+            </h3>
+            <p class="text-sm text-slate-200 leading-relaxed min-h-[80px]">
+                "대부분의 고용주가 <strong>뛰어난 문제 해결 능력</strong>과 <strong>원활한 소통</strong>을 강점으로 꼽았습니다. 특히 일정 준수 항목에서 높은 평가를 받고 있어 신뢰도가 높습니다."
+            </p>
+            <div class="mt-2 text-[10px] text-slate-500 text-right">Based on {{ evaluations.length }} reviews</div>
         </div>
     </div>
 

--- a/freebridgefe/src/views/freelancer/MyPage/components/EvaluationListPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/EvaluationListPage.vue
@@ -151,10 +151,11 @@ const handleAiAnalysis = () => {
     </div>
 
     <!-- Content: Evaluation Summary (3-Column Layout) -->
-    <div v-if="activeTab === 'evaluation' && props.profile" class="space-y-8 animate-fade-in-up">
+    <div v-if="activeTab === 'evaluation'" class="space-y-8 animate-fade-in-up">
         
-        <!-- Top: AI Insight Action / Banner -->
-        <div class="min-h-[180px]">
+        <template v-if="props.profile">
+            <!-- Top: AI Insight Action / Banner -->
+            <div class="min-h-[180px]">
             <!-- State 1: AI Insight Result -->
             <div v-if="showAiAnalysis" class="bg-gradient-to-r from-indigo-900/40 to-purple-900/40 border border-white/10 rounded-3xl p-8 relative overflow-hidden animate-fade-in">
                 <div class="flex flex-col gap-4">
@@ -163,7 +164,7 @@ const handleAiAnalysis = () => {
                         <span class="text-sm font-bold uppercase tracking-wider">AI Insight</span>
                     </div>
                     <div class="space-y-2">
-                        <h2 class="text-2xl font-bold text-white leading-tight" v-html="props.profile.aiSummary?.title || '데이터가 충분하지 않습니다.'"></h2>
+                        <h2 class="text-2xl font-bold text-white leading-tight">{{ props.profile.aiSummary?.title || '데이터가 충분하지 않습니다.' }}</h2>
                         <p class="text-slate-300 leading-relaxed max-w-3xl">
                             {{ props.profile.aiSummary?.description || '평가 분석을 위해 더 많은 프로젝트를 완료해주세요.' }}
                         </p>
@@ -298,6 +299,12 @@ const handleAiAnalysis = () => {
                  </div>
             </div>
 
+        </div>
+        </template>
+        
+        <div v-else class="flex flex-col items-center justify-center py-20 bg-white/5 rounded-3xl border border-white/10 border-dashed text-slate-400 animate-fade-in">
+             <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-white mb-4 opacity-70"></div>
+             <p>평가 데이터를 불러오는 중입니다...</p>
         </div>
     </div>
 

--- a/freebridgefe/src/views/freelancer/MyPage/components/EvaluationListPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/EvaluationListPage.vue
@@ -3,7 +3,6 @@ import { ref, onMounted, computed } from 'vue';
 import { useMotion } from '@vueuse/motion';
 import { 
     Star, 
-    Filter, 
     ArrowLeft, 
     Search,
     MessageSquare,
@@ -28,11 +27,10 @@ const evaluations = ref<Evaluation[]>([]);
 const rejectionFeedbacks = ref<RejectionFeedback[]>([]);
 const isLoading = ref(true);
 
-const activeTab = ref<'project' | 'rejection'>('project');
+const activeTab = ref<'evaluation' | 'rejection'>('evaluation');
 
-// 필터 상태 (Filter & Sort)
+// 필터 상태 (Sort removed)
 const searchQuery = ref('');
-const sortBy = ref<'latest' | 'rating_high' | 'rating_low'>('latest');
 
 onMounted(async () => {
   try {
@@ -50,32 +48,6 @@ onMounted(async () => {
   } finally {
     isLoading.value = false;
   }
-});
-
-// Computed: 검색 및 정렬 로직 (프로젝트 후기용)
-const filteredEvaluations = computed(() => {
-    let result = [...evaluations.value];
-
-    // 1. 검색
-    if (searchQuery.value) {
-        const query = searchQuery.value.toLowerCase();
-        result = result.filter(e => 
-            e.companyName.toLowerCase().includes(query) || 
-            e.projectName.toLowerCase().includes(query)
-        );
-    }
-
-    // 2. 정렬
-    result.sort((a, b) => {
-        if (sortBy.value === 'rating_high') {
-            return b.score - a.score;
-        } else if (sortBy.value === 'rating_low') {
-            return a.score - b.score; 
-        }
-        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-    });
-
-    return result;
 });
 
 // Computed: 검색 로직 (거절 사유용 - 정렬은 최신순 고정)
@@ -98,301 +70,317 @@ const filteredRejections = computed(() => {
 
 // Computed: 평균 평점 (from props if available, else from list)
 const averageScore = computed(() => {
-    if (props.profile) return props.profile.averageRating.toFixed(1);
+    if (props.profile?.averageRating !== undefined) {
+        return Number(props.profile.averageRating).toFixed(1);
+    }
     if (evaluations.value.length === 0) return '0.0';
     const total = evaluations.value.reduce((sum, e) => sum + e.score, 0);
     return (total / evaluations.value.length).toFixed(1);
 });
+
+// Computed: 전문성 평균 점수
+const professionalismScore = computed(() => {
+    if (!props.profile?.expertise) return "0.0";
+    const { programming, framework, problemSolving } = props.profile.expertise;
+    return ((programming + framework + problemSolving) / 3).toFixed(1);
+});
+
+// Computed: 협업 능력 평균 점수
+const collaborationScore = computed(() => {
+    if (!props.profile?.collaboration) return "0.0";
+    const { communication, scheduleAdherence, dispute } = props.profile.collaboration;
+    return ((communication + scheduleAdherence + dispute) / 3).toFixed(1);
+});
+// 평가 항목 한글 매핑 및 설명
+const metricDefinitions: Record<string, { label: string; desc: string }> = {
+    // 전문성
+    programming: { label: '프로그래밍 구현', desc: '코드 품질 및 구조 설계 역량' },
+    framework: { label: '프레임워크 활용', desc: '최신 기술 도구 활용 능력' },
+    problemSolving: { label: '문제 해결 능력', desc: '이슈 원인 분석 및 해결' },
+    // 협업
+    communication: { label: '의사소통', desc: '명확하고 원활한 의견 교환' },
+    scheduleAdherence: { label: '일정 준수', desc: '마감 기한 및 마일스톤 엄수' },
+    dispute: { label: '유연성/대처', desc: '갈등 관리 및 상황 대처 능력' }
+};
+
+// AI 분석 상태
+const showAiAnalysis = ref(false);
+const isAiAnalyzing = ref(false);
+
+const handleAiAnalysis = () => {
+    isAiAnalyzing.value = true;
+    setTimeout(() => {
+        isAiAnalyzing.value = false;
+        showAiAnalysis.value = true;
+    }, 1500); // 1.5초 로딩 시뮬레이션
+};
 </script>
 
 <template>
-  <div class="max-w-5xl mx-auto px-4 md:px-8 py-8 font-sans text-white">
+  <div class="max-w-7xl mx-auto px-4 md:px-8 py-10 font-sans text-white">
     <!-- Header -->
-    <div class="flex items-center gap-4 mb-8">
+    <div class="flex items-center gap-4 mb-10">
         <button
             @click="$emit('back')"
-            class="p-2 hover:bg-white/5 rounded-lg transition-colors"
+            class="p-2 hover:bg-white/5 rounded-full transition-colors"
         >
-            <ArrowLeft class="w-5 h-5 text-white/60" />
+            <ArrowLeft class="w-6 h-6 text-white/80" />
         </button>
         <div>
-            <h1 class="text-2xl font-bold text-white">받은 평가 관리</h1>
-            <p class="text-sm text-slate-400 mt-1">프로젝트 완료 후 받은 고용주의 평가를 확인하세요.</p>
-        </div>
-    </div>
-
-    <!-- Summary Section (New) -->
-    <div v-if="props.profile" class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10 animate-fade-in-up">
-        <!-- Total Average -->
-        <div class="bg-white/5 border border-white/10 rounded-2xl p-6 flex flex-col items-center justify-center gap-2">
-            <div class="text-sm text-slate-400 font-bold">전체 평균 평점</div>
-            <div class="flex items-center gap-2">
-                <Star class="w-8 h-8 text-yellow-400 fill-yellow-400" />
-                <span class="text-4xl font-bold text-white">{{ averageScore }}</span>
-                <span class="text-sm text-slate-500 self-end mb-1">/ 5.0</span>
-            </div>
-            <div class="text-xs text-slate-500 mt-2">총 {{ evaluations.length }}건의 평가 기준</div>
-        </div>
-
-        <!-- Detailed Stats -->
-        <div class="bg-white/5 border border-white/10 rounded-2xl p-6 flex flex-col justify-center">
-            <h3 class="text-sm font-bold text-slate-400 mb-4">항목별 평점 분석</h3>
-            <div class="space-y-4">
-                <!-- Professionalism Average -->
-                <div class="space-y-1">
-                    <div class="flex justify-between text-xs mb-1">
-                        <span class="text-slate-300">전문성 (프로그래밍/프레임워크)</span>
-                        <span class="font-bold text-blue-400">{{ props.profile?.expertise ? ((props.profile.expertise.programming + props.profile.expertise.framework + props.profile.expertise.problemSolving) / 3).toFixed(1) : '0.0' }}</span>
-                    </div>
-                    <div class="h-1.5 bg-slate-700 rounded-full overflow-hidden">
-                        <div class="h-full bg-blue-500" :style="{ width: props.profile?.expertise ? `${(((props.profile.expertise.programming + props.profile.expertise.framework + props.profile.expertise.problemSolving) / 3) / 5) * 100}%` : '0%' }"></div>
-                    </div>
-                </div>
-                 <!-- Collaboration Average -->
-                 <div class="space-y-1">
-                    <div class="flex justify-between text-xs mb-1">
-                        <span class="text-slate-300">협업 능력 (소통/일정준수)</span>
-                        <span class="font-bold text-purple-400">{{ props.profile?.collaboration ? ((props.profile.collaboration.communication + props.profile.collaboration.scheduleAdherence + props.profile.collaboration.dispute) / 3).toFixed(1) : '0.0' }}</span>
-                    </div>
-                    <div class="h-1.5 bg-slate-700 rounded-full overflow-hidden">
-                        <div class="h-full bg-purple-500" :style="{ width: props.profile?.collaboration ? `${(((props.profile.collaboration.communication + props.profile.collaboration.scheduleAdherence + props.profile.collaboration.dispute) / 3) / 5) * 100}%` : '0%' }"></div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- AI Summary -->
-        <div class="bg-gradient-to-br from-indigo-900/40 to-purple-900/40 border border-white/10 rounded-2xl p-6 relative overflow-hidden group">
-            <div class="absolute top-0 right-0 p-4 opacity-50">
-                <Sparkles class="w-12 h-12 text-white/5" />
-            </div>
-            <h3 class="text-sm font-bold text-indigo-300 mb-3 flex items-center gap-2">
-                <Sparkles class="w-4 h-4" />
-                AI 분석 요약
-            </h3>
-            <p class="text-sm text-slate-200 leading-relaxed min-h-[80px]">
-                "대부분의 고용주가 <strong>뛰어난 문제 해결 능력</strong>과 <strong>원활한 소통</strong>을 강점으로 꼽았습니다. 특히 일정 준수 항목에서 높은 평가를 받고 있어 신뢰도가 높습니다."
-            </p>
-            <div class="mt-2 text-[10px] text-slate-500 text-right">Based on {{ evaluations.length }} reviews</div>
+            <h1 class="text-3xl font-bold text-white tracking-tight">받은 평가 관리</h1>
+            <p class="text-base text-slate-400 mt-1">프로젝트 완료 후 받은 고용주의 평가를 확인하세요.</p>
         </div>
     </div>
 
     <!-- Tabs -->
-    <div class="flex gap-1 mb-6 border-b border-white/10">
+    <div class="flex p-1 bg-white/5 rounded-xl mb-8 w-fit border border-white/10">
         <button
-            @click="activeTab = 'project'"
-            class="px-6 py-3 text-sm font-bold border-b-2 transition-colors"
-            :class="activeTab === 'project' ? 'border-blue-500 text-blue-400' : 'border-transparent text-slate-400 hover:text-white'"
+            @click="activeTab = 'evaluation'"
+            class="px-6 py-2.5 text-sm font-bold rounded-lg transition-all duration-300"
+            :class="activeTab === 'evaluation' ? 'bg-white text-black shadow-lg shadow-white/10' : 'text-slate-400 hover:text-white'"
         >
-            프로젝트 후기
+            내 평가 분석
         </button>
         <button
             @click="activeTab = 'rejection'"
-            class="px-6 py-3 text-sm font-bold border-b-2 transition-colors"
-            :class="activeTab === 'rejection' ? 'border-red-500 text-red-400' : 'border-transparent text-slate-400 hover:text-white'"
+            class="px-6 py-2.5 text-sm font-bold rounded-lg transition-all duration-300"
+            :class="activeTab === 'rejection' ? 'bg-red-500 text-white shadow-lg shadow-red-500/20' : 'text-slate-400 hover:text-white'"
         >
-            거절 사유 후기
+            거절 사유
         </button>
     </div>
 
-    <!-- Search & Filter Controls -->
-    <div class="flex flex-col md:flex-row gap-4 mb-6">
-        <div class="relative flex-1">
-            <Search class="w-4 h-4 text-slate-500 absolute left-3 top-3" />
-            <input 
-                type="text" 
-                v-model="searchQuery" 
-                placeholder="프로젝트명 또는 회사명 검색" 
-                class="w-full bg-white/5 border border-white/10 rounded-lg pl-10 pr-4 py-2.5 text-white text-sm outline-none focus:border-blue-500/50 transition-colors"
-            />
-        </div>
-        <div class="relative w-full md:w-48" v-if="activeTab === 'project'">
-            <Filter class="w-4 h-4 text-slate-500 absolute left-3 top-3" />
-            <select 
-                v-model="sortBy"
-                class="w-full bg-white/5 border border-white/10 rounded-lg pl-10 pr-4 py-2.5 text-white text-sm outline-none appearance-none focus:border-blue-500/50 transition-colors"
-            >
-                <option value="latest">최신순</option>
-                <option value="rating_high">평점 높은순</option>
-                <option value="rating_low">평점 낮은순</option>
-            </select>
-        </div>
-    </div>
-
-    <!-- Loading State -->
-    <div v-if="isLoading" class="flex justify-center py-20">
-        <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
-    </div>
-
-    <!-- Content: Project Reviews -->
-    <template v-else-if="activeTab === 'project'">
-        <!-- Empty State -->
-        <div v-if="filteredEvaluations.length === 0" class="flex flex-col items-center justify-center py-20 bg-white/5 rounded-2xl border border-white/10 border-dashed text-slate-500">
-            <MessageSquare class="w-12 h-12 mb-4 opacity-50" />
-            <p>평가 내역이 없습니다.</p>
-        </div>
-
-        <!-- Evaluation List -->
-        <div v-else class="grid grid-cols-1 gap-4">
-            <div 
-                v-for="evaluation in filteredEvaluations" 
-            :key="evaluation.id"
-            class="bg-white/5 rounded-xl border border-white/10 p-6 hover:border-white/20 transition-all group"
-            v-motion
-            :initial="{ opacity: 0, y: 20 }"
-            :enter="{ opacity: 1, y: 0 }"
-        >
-            <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
-                <div class="flex items-start gap-4">
-                    <div class="w-10 h-10 rounded-lg bg-gradient-to-br from-indigo-500/20 to-purple-500/20 flex items-center justify-center border border-white/10 shrink-0">
-                         <Briefcase class="w-5 h-5 text-indigo-400" />
+    <!-- Content: Evaluation Summary (3-Column Layout) -->
+    <div v-if="activeTab === 'evaluation' && props.profile" class="space-y-8 animate-fade-in-up">
+        
+        <!-- Top: AI Insight Action / Banner -->
+        <div class="min-h-[180px]">
+            <!-- State 1: AI Insight Result -->
+            <div v-if="showAiAnalysis" class="bg-gradient-to-r from-indigo-900/40 to-purple-900/40 border border-white/10 rounded-3xl p-8 relative overflow-hidden animate-fade-in">
+                <div class="flex flex-col gap-4">
+                     <div class="flex items-center gap-2 text-indigo-300">
+                        <Sparkles class="w-5 h-5" />
+                        <span class="text-sm font-bold uppercase tracking-wider">AI Insight</span>
                     </div>
-                    <div>
-                        <h3 class="font-bold text-white text-lg leading-tight">{{ evaluation.projectName }}</h3>
-                        <p class="text-sm text-slate-400 mt-1 flex items-center gap-2">
-                             {{ evaluation.companyName }}
+                    <div class="space-y-2">
+                        <h2 class="text-2xl font-bold text-white leading-tight" v-html="props.profile.aiSummary?.title || '데이터가 충분하지 않습니다.'"></h2>
+                        <p class="text-slate-300 leading-relaxed max-w-3xl">
+                            {{ props.profile.aiSummary?.description || '평가 분석을 위해 더 많은 프로젝트를 완료해주세요.' }}
                         </p>
                     </div>
-                </div>
-                <div class="flex flex-col items-end gap-1">
-                    <div class="flex items-center gap-1 bg-yellow-400/10 px-2 py-1 rounded-lg border border-yellow-400/20">
-                        <Star class="w-4 h-4 text-yellow-400 fill-yellow-400" />
-                        <span class="font-bold text-yellow-400 text-sm">{{ evaluation.score.toFixed(1) }}</span>
-                    </div>
-                    <div class="flex items-center gap-1 text-xs text-slate-500 mt-1">
-                        <Calendar class="w-3 h-3" />
-                        {{ evaluation.createdAt }}
+                     <div class="pt-2 flex items-center gap-2 text-xs text-slate-500">
+                        <span>Based on {{ evaluations.length }} verified reviews</span>
                     </div>
                 </div>
             </div>
 
-            <!-- Comment -->
-            <div class="bg-black/20 rounded-lg p-4 mb-6 text-slate-300 text-sm leading-relaxed border border-white/5">
-                "{{ evaluation.comment }}"
-            </div>
-
-            <!-- Detailed Scores -->
-            <div v-if="evaluation.detailedScores" class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6 p-4 bg-white/5 rounded-xl border border-white/5">
-                <!-- Professionalism -->
-                <div>
-                    <h4 class="text-xs font-bold text-slate-500 mb-4 uppercase tracking-wider flex items-center gap-2">
-                        <span class="w-1.5 h-1.5 rounded-full bg-blue-500"></span>
-                        Professionalism
-                    </h4>
-                    <div class="space-y-3">
-                        <div class="flex items-center gap-3 text-sm">
-                            <span class="w-20 text-slate-400 text-xs">프로그래밍</span>
-                            <div class="flex-1 h-1.5 bg-black/40 rounded-full overflow-hidden">
-                                <div class="h-full bg-blue-500 rounded-full" :style="{ width: `${(evaluation.detailedScores.professionalism.programming / 5) * 100}%` }"></div>
-                            </div>
-                            <span class="w-6 text-right font-bold text-white text-xs">{{ evaluation.detailedScores.professionalism.programming }}</span>
-                        </div>
-                        <div class="flex items-center gap-3 text-sm">
-                            <span class="w-20 text-slate-400 text-xs">프레임워크</span>
-                            <div class="flex-1 h-1.5 bg-black/40 rounded-full overflow-hidden">
-                                <div class="h-full bg-blue-500 rounded-full" :style="{ width: `${(evaluation.detailedScores.professionalism.framework / 5) * 100}%` }"></div>
-                            </div>
-                            <span class="w-6 text-right font-bold text-white text-xs">{{ evaluation.detailedScores.professionalism.framework }}</span>
-                        </div>
-                        <div class="flex items-center gap-3 text-sm">
-                            <span class="w-20 text-slate-400 text-xs">문제해결</span>
-                            <div class="flex-1 h-1.5 bg-black/40 rounded-full overflow-hidden">
-                                <div class="h-full bg-blue-500 rounded-full" :style="{ width: `${(evaluation.detailedScores.professionalism.problemSolving / 5) * 100}%` }"></div>
-                            </div>
-                            <span class="w-6 text-right font-bold text-white text-xs">{{ evaluation.detailedScores.professionalism.problemSolving }}</span>
-                        </div>
-                    </div>
+            <!-- State 2: Call to Action Button -->
+            <div v-else class="bg-white/5 border border-white/10 rounded-3xl p-8 flex flex-col md:flex-row items-center justify-between gap-6 relative overflow-hidden group">
+                <div class="absolute inset-0 bg-gradient-to-r from-indigo-500/5 to-purple-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500"></div>
+                
+                <div class="relative z-10">
+                    <h2 class="text-xl font-bold text-white mb-2 flex items-center gap-2">
+                        <Sparkles class="w-5 h-5 text-indigo-400" />
+                        AI 평가 상세 분석
+                    </h2>
+                    <p class="text-slate-400 text-sm max-w-md">
+                        프리브릿지 AI가 고용주들의 평가 데이터를 분석하여<br/>
+                        귀하의 강점과 보완점을 요약해드립니다.
+                    </p>
                 </div>
-
-                <!-- Collaboration -->
-                <div>
-                    <h4 class="text-xs font-bold text-slate-500 mb-4 uppercase tracking-wider flex items-center gap-2">
-                        <span class="w-1.5 h-1.5 rounded-full bg-purple-500"></span>
-                        Collaboration
-                    </h4>
-                    <div class="space-y-3">
-                        <div class="flex items-center gap-3 text-sm">
-                            <span class="w-20 text-slate-400 text-xs">의사소통</span>
-                            <div class="flex-1 h-1.5 bg-black/40 rounded-full overflow-hidden">
-                                <div class="h-full bg-purple-500 rounded-full" :style="{ width: `${(evaluation.detailedScores.collaboration.communication / 5) * 100}%` }"></div>
-                            </div>
-                            <span class="w-6 text-right font-bold text-white text-xs">{{ evaluation.detailedScores.collaboration.communication }}</span>
-                        </div>
-                        <div class="flex items-center gap-3 text-sm">
-                            <span class="w-20 text-slate-400 text-xs">일정준수</span>
-                            <div class="flex-1 h-1.5 bg-black/40 rounded-full overflow-hidden">
-                                <div class="h-full bg-purple-500 rounded-full" :style="{ width: `${(evaluation.detailedScores.collaboration.scheduleAdherence / 5) * 100}%` }"></div>
-                            </div>
-                            <span class="w-6 text-right font-bold text-white text-xs">{{ evaluation.detailedScores.collaboration.scheduleAdherence }}</span>
-                        </div>
-                        <div class="flex items-center gap-3 text-sm">
-                            <span class="w-20 text-slate-400 text-xs">분쟁관리</span>
-                            <div class="flex-1 h-1.5 bg-black/40 rounded-full overflow-hidden">
-                                <div class="h-full bg-purple-500 rounded-full" :style="{ width: `${(evaluation.detailedScores.collaboration.dispute / 5) * 100}%` }"></div>
-                            </div>
-                            <span class="w-6 text-right font-bold text-white text-xs">{{ evaluation.detailedScores.collaboration.dispute }}</span>
-                        </div>
-                    </div>
+                
+                <div class="relative z-10">
+                    <button 
+                        @click="handleAiAnalysis"
+                        :disabled="isAiAnalyzing"
+                        class="px-8 py-3 bg-indigo-600 hover:bg-indigo-500 text-white rounded-xl font-bold shadow-lg shadow-indigo-500/20 transition-all flex items-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed"
+                    >
+                         <div v-if="isAiAnalyzing" class="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
+                         <Sparkles v-else class="w-5 h-5 fill-white/20" />
+                         <span v-if="isAiAnalyzing">분석중...</span>
+                         <span v-else>AI 분석 받아보기</span>
+                    </button>
                 </div>
-            </div>
-
-            <!-- Tags -->
-            <div class="flex flex-wrap gap-2">
-                <span 
-                    v-for="tag in evaluation.tags" 
-                    :key="tag" 
-                    class="text-xs px-2.5 py-1 rounded-full bg-white/5 text-slate-300 border border-white/10"
-                >
-                    #{{ tag }}
-                </span>
             </div>
         </div>
-        </div>
-    </template>
 
-    <!-- Content: Rejection Feedback -->
+        <!-- Metric Cards Grid (3 Columns) -->
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+            
+            <!-- 1. Professionalism Card -->
+             <div class="bg-white/5 border border-white/10 rounded-3xl p-8 hover:border-blue-500/30 transition-colors duration-300 flex flex-col">
+                <div class="flex justify-between items-start mb-6">
+                    <div>
+                        <div class="flex items-center gap-2 mb-2">
+                            <div class="p-2 bg-blue-500/10 rounded-lg">
+                                <Briefcase class="w-5 h-5 text-blue-400" />
+                            </div>
+                            <span class="text-sm font-bold text-blue-400">전문성</span>
+                        </div>
+                    </div>
+                    <div class="text-right">
+                         <div class="text-3xl font-bold text-white tracking-tight">{{ professionalismScore }}</div>
+                         <div class="text-xs text-slate-500">/ 5.0</div>
+                    </div>
+                </div>
+                
+                <div class="space-y-6 flex-1">
+                    <div v-for="(score, key) in props.profile?.expertise" :key="key" class="space-y-2">
+                        <div class="flex justify-between items-end mb-1">
+                            <div>
+                                <span class="text-slate-200 text-sm font-bold block">{{ metricDefinitions[key]?.label || key }}</span>
+                                <span class="text-slate-500 text-xs">{{ metricDefinitions[key]?.desc || '' }}</span>
+                            </div>
+                            <span class="text-white font-bold text-sm">{{ score.toFixed(1) }}</span>
+                        </div>
+                        <div class="h-1.5 bg-slate-700/30 rounded-full overflow-hidden">
+                            <div class="h-full bg-blue-500 rounded-full" 
+                                    :style="{ width: `${(score / 5) * 100}%` }"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 2. Collaboration Card -->
+            <div class="bg-white/5 border border-white/10 rounded-3xl p-8 hover:border-purple-500/30 transition-colors duration-300 flex flex-col">
+                <div class="flex justify-between items-start mb-6">
+                    <div>
+                        <div class="flex items-center gap-2 mb-2">
+                            <div class="p-2 bg-purple-500/10 rounded-lg">
+                                <MessageSquare class="w-5 h-5 text-purple-400" />
+                            </div>
+                            <span class="text-sm font-bold text-purple-400">협업 능력</span>
+                        </div>
+                    </div>
+                    <div class="text-right">
+                         <div class="text-3xl font-bold text-white tracking-tight">{{ collaborationScore }}</div>
+                         <div class="text-xs text-slate-500">/ 5.0</div>
+                    </div>
+                </div>
+
+                <div class="space-y-6 flex-1">
+                     <div v-for="(score, key) in props.profile?.collaboration" :key="key" class="space-y-2">
+                        <div class="flex justify-between items-end mb-1">
+                             <div>
+                                <span class="text-slate-200 text-sm font-bold block">{{ metricDefinitions[key]?.label || key }}</span>
+                                <span class="text-slate-500 text-xs">{{ metricDefinitions[key]?.desc || '' }}</span>
+                            </div>
+                            <span class="text-white font-bold text-sm">{{ score.toFixed(1) }}</span>
+                        </div>
+                        <div class="h-1.5 bg-slate-700/30 rounded-full overflow-hidden">
+                            <div class="h-full bg-purple-500 rounded-full" 
+                                    :style="{ width: `${(score / 5) * 100}%` }"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+             <!-- 3. Total Average Card -->
+            <div class="bg-white/5 border border-white/10 rounded-3xl p-8 hover:border-yellow-500/30 transition-colors duration-300 flex flex-col justify-center items-center text-center relative overflow-hidden group">
+                 <div class="absolute inset-0 bg-yellow-500/5 group-hover:bg-yellow-500/10 transition-colors duration-500"></div>
+                 
+                 <div class="relative z-10">
+                    <div class="mb-4 inline-flex p-4 bg-yellow-500/10 rounded-full">
+                        <Star class="w-10 h-10 text-yellow-400 fill-yellow-400" />
+                    </div>
+                    <div class="space-y-2">
+                        <span class="block text-sm font-bold text-yellow-500 uppercase tracking-wider">Total Score</span>
+                        <div class="flex items-center justify-center gap-3">
+                            <span class="text-6xl font-bold text-white tracking-tight">{{ averageScore }}</span>
+                        </div>
+                         <span class="block text-sm text-slate-400 font-medium">/ 5.0 만점</span>
+                    </div>
+                    <div class="mt-8 pt-6 border-t border-white/10 w-full">
+                        <div class="text-sm text-slate-300">
+                            상위 <span class="font-bold text-yellow-400">{{ props.profile?.topPercentile || 0 }}%</span> 이내의<br/>우수한 평가를 받고 있습니다.
+                        </div>
+                    </div>
+                 </div>
+            </div>
+
+        </div>
+    </div>
+
     <template v-else-if="activeTab === 'rejection'">
-        <!-- Empty State -->
-        <div v-if="filteredRejections.length === 0" class="flex flex-col items-center justify-center py-20 bg-white/5 rounded-2xl border border-white/10 border-dashed text-slate-500">
-            <MessageSquare class="w-12 h-12 mb-4 opacity-50" />
-            <p>거절 사유 후기가 없습니다.</p>
+        <!-- Section Title -->
+        <div class="mb-6 border-b border-white/10 pb-4">
+            <h3 class="text-lg font-bold text-white flex items-center gap-2">
+                거절 사유 후기
+                <span class="text-xs font-normal text-slate-400 px-2 py-0.5 bg-white/5 rounded-full">{{ filteredRejections.length }}</span>
+            </h3>
+        </div>
+
+        <!-- Search & Filter Controls -->
+        <div class="flex flex-col md:flex-row gap-4 mb-6">
+            <div class="relative flex-1">
+                <Search class="w-4 h-4 text-slate-500 absolute left-3 top-3" />
+                <input 
+                    type="text" 
+                    v-model="searchQuery" 
+                    placeholder="프로젝트명 또는 회사명 검색" 
+                    class="w-full bg-white/5 border border-white/10 rounded-lg pl-10 pr-4 py-2.5 text-white text-sm outline-none focus:border-blue-500/50 transition-colors"
+                />
+            </div>
+        </div>
+
+        <!-- Loading State -->
+        <div v-if="isLoading" class="flex justify-center py-20">
+            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
         </div>
 
         <!-- Rejection List -->
-        <div v-else class="grid grid-cols-1 gap-4">
+        <template v-else>
+            <!-- Empty State -->
+            <div v-if="filteredRejections.length === 0" class="flex flex-col items-center justify-center py-20 bg-white/5 rounded-2xl border border-white/10 border-dashed text-slate-500">
+                <MessageSquare class="w-12 h-12 mb-4 opacity-50" />
+                <p>거절 사유 후기가 없습니다.</p>
+            </div>
+
+            <!-- List -->
+            <div v-else class="grid grid-cols-1 gap-4">
             <div 
                 v-for="feedback in filteredRejections" 
                 :key="feedback.id"
-                class="bg-white/5 rounded-xl border border-white/10 p-6 hover:border-white/20 transition-all group"
+                class="bg-white/5 rounded-xl border border-white/10 p-6 hover:border-red-500/30 transition-all group"
                 v-motion
                 :initial="{ opacity: 0, y: 20 }"
                 :enter="{ opacity: 1, y: 0 }"
             >
                 <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
                     <div class="flex items-start gap-4">
-                        <div class="w-10 h-10 rounded-lg bg-red-500/10 flex items-center justify-center border border-red-500/20 shrink-0">
+                         <div class="w-10 h-10 rounded-lg bg-red-400/10 flex items-center justify-center border border-red-400/20 shrink-0">
                              <Briefcase class="w-5 h-5 text-red-400" />
                         </div>
                         <div>
-                            <h3 class="font-bold text-white text-lg leading-tight">{{ feedback.projectName }}</h3>
+                            <h3 class="font-bold text-white text-lg leading-tight group-hover:text-red-400 transition-colors">{{ feedback.projectName }}</h3>
                             <p class="text-sm text-slate-400 mt-1 flex items-center gap-2">
-                                 {{ feedback.companyName }}
+                                {{ feedback.companyName }}
                             </p>
                         </div>
                     </div>
-                    <div class="flex items-center gap-1 text-xs text-slate-500 mt-1">
+                    <div class="text-xs text-slate-500 flex items-center gap-1">
                         <Calendar class="w-3 h-3" />
-                        {{ feedback.createdAt }}
+                         {{ feedback.createdAt }}
                     </div>
                 </div>
 
-                <!-- Reason -->
-                <div class="bg-red-500/5 rounded-lg p-4 text-slate-300 text-sm leading-relaxed border border-red-500/10">
-                    <h4 class="text-xs font-bold text-red-400 mb-2 uppercase tracking-wider">거절 사유</h4>
+                <div class="bg-black/20 rounded-lg p-4 text-slate-300 text-sm leading-relaxed border border-white/5 mb-4">
                     "{{ feedback.reason }}"
+                </div>
+                
+                <div class="flex flex-wrap gap-2">
+                     <span 
+                        v-for="tag in feedback.tags" 
+                        :key="tag" 
+                        class="text-xs px-2.5 py-1 rounded-full bg-red-400/10 text-red-300 border border-red-400/20"
+                    >
+                        #{{ tag }}
+                    </span>
                 </div>
             </div>
         </div>
+
+    </template>
     </template>
   </div>
 </template>

--- a/freebridgefe/src/views/freelancer/MyPage/components/GradeCheckPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/GradeCheckPage.vue
@@ -1,7 +1,16 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { useMotion } from '@vueuse/motion';
-import { ArrowLeft, Award, GraduationCap, CheckCircle, Info, Save, Loader2 } from 'lucide-vue-next';
+import { 
+    ArrowLeft, 
+    Award, 
+    GraduationCap, 
+    CheckCircle, 
+    Info, 
+    Save, 
+    Loader2,
+    Briefcase
+} from 'lucide-vue-next';
 import { 
     type GradeLevel, 
     type EducationType, 
@@ -21,10 +30,10 @@ const emit = defineEmits<{
 }>();
 
 const selectedType = ref<'education' | 'certification'>('education');
-const education = ref<EducationType>('전문학사'); // Default to first option or handle empty
-const yearsOfExperience = ref<number>(0);
-const certification = ref<CertificationType>('산업기사'); // Default
-const certYears = ref<number>(0);
+const education = ref<EducationType | ''>(''); 
+const yearsOfExperience = ref<number | ''>('');
+const certification = ref<CertificationType | ''>(''); 
+const certYears = ref<number | ''>('');
 const calculatedGrade = ref<GradeLevel>('');
 
 const educationOptions = ref<EducationOption[]>([]);
@@ -61,11 +70,14 @@ const handleCalculate = async () => {
     calculatedGrade.value = ''; // Reset result
     
     try {
+        // Simulate slight delay for effect
+        await new Promise(resolve => setTimeout(resolve, 600));
+
         const result = await calculateGrade({
             type: selectedType.value,
-            education: selectedType.value === 'education' ? education.value : undefined,
-            certification: selectedType.value === 'certification' ? certification.value : undefined,
-            yearsOfExperience: selectedType.value === 'education' ? yearsOfExperience.value : certYears.value
+            education: selectedType.value === 'education' ? (education.value as EducationType) : undefined,
+            certification: selectedType.value === 'certification' ? (certification.value as CertificationType) : undefined,
+            yearsOfExperience: selectedType.value === 'education' ? Number(yearsOfExperience.value) : Number(certYears.value)
         });
         calculatedGrade.value = result;
     } catch (error) {
@@ -82,9 +94,9 @@ const handleSave = async () => {
     try {
         await saveGrade({
             type: selectedType.value,
-            education: selectedType.value === 'education' ? education.value : undefined,
-            certification: selectedType.value === 'certification' ? certification.value : undefined,
-            yearsOfExperience: selectedType.value === 'education' ? yearsOfExperience.value : certYears.value,
+            education: selectedType.value === 'education' ? (education.value as EducationType) : undefined,
+            certification: selectedType.value === 'certification' ? (certification.value as CertificationType) : undefined,
+            yearsOfExperience: selectedType.value === 'education' ? Number(yearsOfExperience.value) : Number(certYears.value),
             grade: calculatedGrade.value
         });
         alert('등급 정보가 성공적으로 저장되었습니다.');
@@ -98,295 +110,281 @@ const handleSave = async () => {
 
 const getGradeColor = (grade: GradeLevel) => {
     switch (grade) {
-        case '특급': return 'from-purple-600 to-pink-600';
-        case '고급': return 'from-blue-500 to-cyan-500';
-        case '중급': return 'from-green-500 to-emerald-500';
-        case '초급': return 'from-slate-500 to-slate-600';
-        default: return 'from-slate-700 to-slate-800';
+        case '특급': return 'from-purple-600 to-pink-600 shadow-purple-500/30';
+        case '고급': return 'from-blue-500 to-cyan-500 shadow-blue-500/30';
+        case '중급': return 'from-emerald-500 to-teal-500 shadow-emerald-500/30';
+        case '초급': return 'from-slate-500 to-slate-600 shadow-slate-500/30';
+        default: return 'from-slate-700 to-slate-800 shadow-slate-900/10';
     }
 };
 
 const getGradeBadgeColor = (grade: string) => {
     switch (grade) {
-        case '특급': return 'bg-purple-600';
-        case '고급': return 'bg-blue-500';
-        case '중급': return 'bg-green-500';
-        case '초급': return 'bg-slate-500';
+        case '특급': return 'bg-purple-500 shadow-lg shadow-purple-500/50';
+        case '고급': return 'bg-blue-500 shadow-lg shadow-blue-500/50';
+        case '중급': return 'bg-emerald-500 shadow-lg shadow-emerald-500/50';
+        case '초급': return 'bg-slate-500 shadow-lg shadow-slate-500/50';
         default: return 'bg-slate-700';
     }
 };
 </script>
 
 <template>
-  <div class="max-w-5xl mx-auto px-4 md:px-8 py-8 font-sans text-white">
+  <div class="max-w-7xl mx-auto px-4 md:px-8 py-10 font-sans text-white">
     <!-- Header -->
-    <div class="flex items-center gap-4 mb-8">
+    <div class="flex items-center gap-4 mb-10">
         <button
             @click="$emit('back')"
-            class="p-2 hover:bg-white/5 rounded-lg transition-colors"
-            v-motion
-            :hover="{ scale: 1.1 }"
-            :tap="{ scale: 0.9 }"
+            class="p-2 hover:bg-white/5 rounded-full transition-colors"
         >
-            <ArrowLeft class="w-5 h-5 text-white/60" />
+            <ArrowLeft class="w-6 h-6 text-white/80" />
         </button>
         <div>
-            <h1 class="text-2xl font-bold text-white">회원 등급 조회</h1>
-            <p class="text-sm text-slate-400 mt-1">학력/경력 또는 자격증 정보를 입력하여 등급을 확인하세요</p>
+            <h1 class="text-3xl font-bold text-white tracking-tight">회원 등급 조회</h1>
+            <p class="text-base text-slate-400 mt-1">학력, 경력, 자격증 정보를 바탕으로 나의 등급을 확인해보세요.</p>
         </div>
     </div>
 
-    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        <!-- Input Form -->
-        <div class="lg:col-span-2 space-y-6">
-            <!-- Type Selection -->
-            <div
-                class="bg-white/5 rounded-2xl border border-white/10 p-6"
-                v-motion
-                :initial="{ opacity: 0, y: 20 }"
-                :enter="{ opacity: 1, y: 0 }"
-            >
-                <h2 class="text-lg font-bold text-white mb-4 flex items-center gap-2">
-                    <Award class="w-5 h-5 text-yellow-400" />
-                    등급 산정 방식 선택
-                </h2>
-                <div class="grid grid-cols-2 gap-4">
-                    <button
-                        @click="selectedType = 'education'; calculatedGrade = ''"
-                        class="p-4 rounded-xl border-2 transition-all flex flex-col items-center justify-center text-center"
-                        :class="selectedType === 'education'
-                            ? 'border-blue-500 bg-blue-500/10'
-                            : 'border-white/10 bg-white/5 hover:bg-white/10'"
-                    >
-                        <GraduationCap
-                            class="w-8 h-8 mb-2"
-                            :class="selectedType === 'education' ? 'text-blue-400' : 'text-slate-400'"
-                        />
-                        <div
-                            class="font-semibold"
-                            :class="selectedType === 'education' ? 'text-blue-300' : 'text-slate-300'"
-                        >
-                            학경력자
-                        </div>
-                        <div class="text-xs text-slate-500 mt-1">학력 + 경력</div>
-                    </button>
-                    <button
-                        @click="selectedType = 'certification'; calculatedGrade = ''"
-                        class="p-4 rounded-xl border-2 transition-all flex flex-col items-center justify-center text-center"
-                        :class="selectedType === 'certification'
-                            ? 'border-green-500 bg-green-500/10'
-                            : 'border-white/10 bg-white/5 hover:bg-white/10'"
-                    >
-                        <Award
-                            class="w-8 h-8 mb-2"
-                            :class="selectedType === 'certification' ? 'text-green-400' : 'text-slate-400'"
-                        />
-                        <div
-                            class="font-semibold"
-                            :class="selectedType === 'certification' ? 'text-green-300' : 'text-slate-300'"
-                        >
-                            자격자
-                        </div>
-                        <div class="text-xs text-slate-500 mt-1">자격증 + 경력</div>
-                    </button>
-                </div>
-            </div>
-
-            <!-- Education Form -->
-            <div
-                v-if="selectedType === 'education'"
-                class="bg-white/5 rounded-2xl border border-white/10 p-6"
-                v-motion
-                :initial="{ opacity: 0, y: 20 }"
-                :enter="{ opacity: 1, y: 0 }"
-            >
-                <h2 class="text-lg font-bold text-white mb-4 flex items-center gap-2">
-                    <GraduationCap class="w-5 h-5 text-blue-400" />
-                    학력 및 경력 정보
-                </h2>
-
-                <div class="space-y-4">
-                     <div>
-                        <label class="text-sm text-slate-400 mb-2 block">최종 학력</label>
-                        <select
-                            v-model="education"
-                            @change="calculatedGrade = ''"
-                            class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white outline-none focus:border-blue-500 transition-colors"
-                        >
-                            <option value="" disabled>선택하세요</option>
-                            <option 
-                                v-for="opt in educationOptions" 
-                                :key="opt.value" 
-                                :value="opt.value" 
-                                class="text-black"
-                            >
-                                {{ opt.label }}
-                            </option>
-                        </select>
+    <div class="grid grid-cols-1 lg:grid-cols-12 gap-8">
+        <!-- Left Column: Input Form -->
+        <div class="lg:col-span-7 space-y-6 animate-fade-in-up">
+            
+            <!-- Type Selection Cards -->
+            <div class="grid grid-cols-2 gap-4">
+                <button
+                    @click="selectedType = 'education'; calculatedGrade = ''"
+                    class="relative p-6 rounded-3xl border transition-all duration-300 flex flex-col items-center justify-center text-center group overflow-hidden"
+                    :class="selectedType === 'education'
+                        ? 'bg-blue-500/20 border-blue-500/50 shadow-lg shadow-blue-500/10'
+                        : 'bg-white/5 border-white/10 hover:bg-white/10'"
+                >
+                    <div class="absolute inset-0 bg-gradient-to-br from-blue-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" v-if="selectedType !== 'education'"></div>
+                    <div class="p-3 bg-blue-500/20 rounded-2xl mb-3 group-hover:scale-110 transition-transform duration-300">
+                        <GraduationCap class="w-8 h-8 text-blue-400" />
                     </div>
-                    <div>
-                        <label class="text-sm text-slate-400 mb-2 block">경력 연수 (년)</label>
-                        <input
-                            type="number"
-                            min="0"
-                            v-model.number="yearsOfExperience"
-                            @input="calculatedGrade = ''"
-                            class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white outline-none focus:border-blue-500 transition-colors"
-                            placeholder="경력 연수를 입력하세요"
-                        />
-                    </div>
-                </div>
-            </div>
-
-            <!-- Certification Form -->
-            <div
-                v-if="selectedType === 'certification'"
-                class="bg-white/5 rounded-2xl border border-white/10 p-6"
-                v-motion
-                :initial="{ opacity: 0, y: 20 }"
-                :enter="{ opacity: 1, y: 0 }"
-            >
-                <h2 class="text-lg font-bold text-white mb-4 flex items-center gap-2">
-                    <Award class="w-5 h-5 text-green-400" />
-                    자격증 및 경력 정보
-                </h2>
-
-                 <div class="space-y-4">
-                     <div>
-                        <label class="text-sm text-slate-400 mb-2 block">자격증</label>
-                        <select
-                            v-model="certification"
-                            @change="calculatedGrade = ''"
-                            class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white outline-none focus:border-green-500 transition-colors"
-                        >
-                             <option value="" disabled>선택하세요</option>
-                             <option 
-                                v-for="opt in certificationOptions" 
-                                :key="opt.value" 
-                                :value="opt.value" 
-                                class="text-black"
-                            >
-                                {{ opt.label }}
-                            </option>
-                        </select>
-                    </div>
-                    <div>
-                        <label class="text-sm text-slate-400 mb-2 block">경력 연수 (년)</label>
-                        <input
-                            type="number"
-                            min="0"
-                            v-model.number="certYears"
-                            @input="calculatedGrade = ''"
-                            class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-3 text-white outline-none focus:border-green-500 transition-colors"
-                            placeholder="경력 연수를 입력하세요"
-                        />
-                    </div>
-                </div>
-            </div>
-
-            <button
-                @click="handleCalculate"
-                :disabled="(selectedType === 'education' ? !education : !certification) || isLoading"
-                class="w-full py-4 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-500 hover:to-purple-500 disabled:from-slate-700 disabled:to-slate-800 disabled:cursor-not-allowed text-white font-bold rounded-xl transition-all shadow-lg hover:shadow-xl disabled:shadow-none flex items-center justify-center gap-2"
-                v-motion
-                :hover="{ scale: 1.02 }"
-                :tap="{ scale: 0.98 }"
-            >
-                <Loader2 v-if="isLoading" class="w-5 h-5 animate-spin" />
-                <span v-else>등급 계산하기</span>
-            </button>
-        </div>
-
-         <!-- Right Column - Result & Guide -->
-        <div class="space-y-6">
-             <div
-                class="rounded-2xl p-6 text-center min-h-[200px] flex flex-col items-center justify-center transition-colors duration-500"
-                :class="`bg-gradient-to-br ${getGradeColor(calculatedGrade)}`"
-                v-motion
-                :initial="{ opacity: 0, scale: 0.9 }"
-                :enter="{ opacity: 1, scale: 1 }"
-            >
-                <template v-if="calculatedGrade">
-                    <CheckCircle class="w-12 h-12 text-white mb-4" />
-                    <div class="text-sm text-white/80 mb-2">귀하의 등급은</div>
-                    <div class="text-5xl font-bold text-white mb-2">{{ calculatedGrade }}</div>
-                    <div class="text-sm text-white/80 mb-6">입니다</div>
+                    <div class="font-bold text-lg text-white mb-1">학경력자</div>
+                    <div class="text-xs text-slate-400">학력 + 경력 기준 산정</div>
                     
-                    <div class="mb-6 p-4 bg-red-500/10 border border-red-500/20 rounded-xl flex items-start gap-3 text-left">
-                        <Info class="w-5 h-5 text-red-500 shrink-0 mt-0.5" />
-                        <div>
-                            <h4 class="text-red-400 font-bold text-sm mb-1">허위 정보 입력 시 주의사항</h4>
-                            <p class="text-xs text-red-300/80 leading-relaxed">
-                                해당 등급은 입력하신 정보를 바탕으로 산정됩니다. 
-                                실제 정보와 다를 경우 <span class="text-red-400 font-bold decoration-wavy underline">고용주와의 법적 분쟁 및 손해배상 청구</span>의 대상이 될 수 있습니다.
-                            </p>
-                        </div>
+                    <div v-if="selectedType === 'education'" class="absolute top-4 right-4">
+                        <CheckCircle class="w-5 h-5 text-blue-400 fill-blue-400/20" />
                     </div>
+                </button>
 
-                     <button
-                        @click="handleSave"
-                        :disabled="isSaving"
-                        class="px-6 py-2 bg-white/20 hover:bg-white/30 rounded-lg text-white text-sm font-semibold transition-colors flex items-center gap-2 mx-auto"
-                    >
-                        <Loader2 v-if="isSaving" class="w-4 h-4 animate-spin" />
-                        <Save v-else class="w-4 h-4" />
-                        등급 정보 저장
-                    </button>
-                </template>
-                <template v-else>
-                     <Award class="w-12 h-12 text-white/40 mb-4" />
-                    <div class="text-white/60">정보를 입력하고</div>
-                    <div class="text-white/60">등급을 계산해보세요</div>
-                </template>
+                <button
+                    @click="selectedType = 'certification'; calculatedGrade = ''"
+                    class="relative p-6 rounded-3xl border transition-all duration-300 flex flex-col items-center justify-center text-center group overflow-hidden"
+                    :class="selectedType === 'certification'
+                        ? 'bg-emerald-500/20 border-emerald-500/50 shadow-lg shadow-emerald-500/10'
+                        : 'bg-white/5 border-white/10 hover:bg-white/10'"
+                >
+                    <div class="absolute inset-0 bg-gradient-to-br from-emerald-500/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" v-if="selectedType !== 'certification'"></div>
+                     <div class="p-3 bg-emerald-500/20 rounded-2xl mb-3 group-hover:scale-110 transition-transform duration-300">
+                        <Award class="w-8 h-8 text-emerald-400" />
+                    </div>
+                    <div class="font-bold text-lg text-white mb-1">자격자</div>
+                    <div class="text-xs text-slate-400">자격증 + 경력 기준 산정</div>
+
+                    <div v-if="selectedType === 'certification'" class="absolute top-4 right-4">
+                        <CheckCircle class="w-5 h-5 text-emerald-400 fill-emerald-400/20" />
+                    </div>
+                </button>
             </div>
 
-             <div
-                class="bg-white/5 rounded-2xl border border-white/10 p-6"
-                v-motion
-                :initial="{ opacity: 0, y: 20 }"
-                :enter="{ opacity: 1, y: 0, transition: { delay: 100 } }"
-            >
-                <h3 class="text-sm font-bold text-white mb-4 flex items-center gap-2">
-                    <Info class="w-4 h-4 text-blue-400" />
-                    등급 안내
-                </h3>
-                  <div class="space-y-2">
-                    <div v-for="grade in ['특급', '고급', '중급', '초급']" :key="grade" class="flex items-center gap-2">
-                        <div class="w-3 h-3 rounded-full" :class="getGradeBadgeColor(grade)"></div>
-                        <span class="text-xs text-slate-300">{{ grade }}</span>
+            <!-- Input Fields -->
+            <div class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-sm">
+                <!-- Education Inputs -->
+                <div v-if="selectedType === 'education'" class="space-y-6 animate-fade-in">
+                    <h2 class="text-xl font-bold text-white flex items-center gap-2 mb-6">
+                        <GraduationCap class="w-5 h-5 text-blue-400" />
+                        학력 및 경력 정보 입력
+                    </h2>
+                     <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">최종 학력</label>
+                        <div class="relative">
+                            <select
+                                v-model="education"
+                                @change="calculatedGrade = ''"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl px-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all appearance-none"
+                            >
+                                <option value="" disabled selected>선택하세요</option>
+                                <option 
+                                    v-for="opt in educationOptions" 
+                                    :key="opt.value" 
+                                    :value="opt.value"
+                                    class="bg-[#1e293b]"
+                                >
+                                    {{ opt.label }}
+                                </option>
+                            </select>
+                            <div class="absolute right-4 top-3.5 pointer-events-none text-slate-500">▼</div>
+                        </div>
                     </div>
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">IT 분야 경력 (년)</label>
+                        <div class="relative">
+                            <Briefcase class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
+                            <input
+                                type="number"
+                                min="0"
+                                v-model.number="yearsOfExperience"
+                                @input="calculatedGrade = ''"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
+                                placeholder="예: 3"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Certification Inputs -->
+                <div v-if="selectedType === 'certification'" class="space-y-6 animate-fade-in">
+                    <h2 class="text-xl font-bold text-white flex items-center gap-2 mb-6">
+                        <Award class="w-5 h-5 text-emerald-400" />
+                        자격증 및 경력 정보 입력
+                    </h2>
+                     <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">보유 자격증</label>
+                        <div class="relative">
+                            <select
+                                v-model="certification"
+                                @change="calculatedGrade = ''"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl px-4 py-3 text-white text-sm outline-none focus:border-emerald-500/50 focus:bg-[#1e293b] transition-all appearance-none"
+                            >
+                                 <option value="" disabled selected>선택하세요</option>
+                                 <option 
+                                    v-for="opt in certificationOptions" 
+                                    :key="opt.value" 
+                                    :value="opt.value"
+                                    class="bg-[#1e293b]"
+                                >
+                                    {{ opt.label }}
+                                </option>
+                            </select>
+                            <div class="absolute right-4 top-3.5 pointer-events-none text-slate-500">▼</div>
+                        </div>
+                    </div>
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">IT 분야 경력 (년)</label>
+                        <div class="relative">
+                            <Briefcase class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
+                            <input
+                                type="number"
+                                min="0"
+                                v-model.number="certYears"
+                                @input="calculatedGrade = ''"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-white text-sm outline-none focus:border-emerald-500/50 focus:bg-[#1e293b] transition-all"
+                                placeholder="예: 3"
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                <div class="mt-8 pt-6 border-t border-white/5">
+                    <button
+                        @click="handleCalculate"
+                        :disabled="(selectedType === 'education' ? !education : !certification) || isLoading"
+                        class="w-full py-4 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 disabled:from-slate-700 disabled:to-slate-800 disabled:cursor-not-allowed text-white font-bold rounded-xl transition-all shadow-lg hover:shadow-blue-500/25 disabled:shadow-none flex items-center justify-center gap-2"
+                    >
+                        <Loader2 v-if="isLoading" class="w-5 h-5 animate-spin" />
+                        <span v-else>나의 등급 계산하기</span>
+                    </button>
+                </div>
+            </div>
+
+            <!-- Grade Criteria Table -->
+             <div class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-sm">
+                <h3 class="text-lg font-bold text-white mb-6 flex items-center gap-2">
+                    <Info class="w-5 h-5 text-slate-400" />
+                    등급 산정 기준표
+                </h3>
+                 <div class="overflow-x-auto">
+                    <table class="w-full text-sm text-left">
+                        <thead>
+                            <tr class="border-b border-white/10">
+                                <th class="py-3 px-4 text-slate-300 font-bold w-20">등급</th>
+                                <th class="py-3 px-4 text-slate-300 font-semibold">학경력자 기준</th>
+                                <th class="py-3 px-4 text-slate-300 font-semibold">자격자 기준</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-white/5">
+                             <tr v-for="item in criteriaList" :key="item.grade" class="hover:bg-white/5 transition-colors">
+                                <td class="py-4 px-4">
+                                    <span :class="`inline-flex items-center justify-center px-2.5 py-1 rounded-md text-xs font-bold text-white ${getGradeBadgeColor(item.grade)}`">{{ item.grade }}</span>
+                                </td>
+                                <td class="py-4 px-4 text-slate-300 text-xs leading-relaxed">{{ item.edu }}</td>
+                                <td class="py-4 px-4 text-slate-300 text-xs leading-relaxed">{{ item.cert }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
             </div>
         </div>
-    </div>
 
-    <!-- Criteria Table -->
-    <div
-        class="mt-8 bg-white/5 rounded-2xl border border-white/10 p-6"
-        v-motion
-        :initial="{ opacity: 0, y: 20 }"
-        :enter="{ opacity: 1, y: 0, transition: { delay: 200 } }"
-    >
-        <h2 class="text-lg font-bold text-white mb-4">등급 산정 기준표</h2>
-        <div class="overflow-x-auto">
-            <table class="w-full text-sm">
-                <thead>
-                    <tr class="border-b border-white/10">
-                        <th class="text-left py-3 px-4 text-slate-300 font-semibold">등급</th>
-                        <th class="text-left py-3 px-4 text-slate-300 font-semibold">학경력자</th>
-                        <th class="text-left py-3 px-4 text-slate-300 font-semibold">자격자</th>
-                    </tr>
-                </thead>
-                <tbody>
-                     <tr v-for="item in criteriaList" :key="item.grade" class="border-b border-white/10 hover:bg-white/5">
-                        <td class="py-3 px-4">
-                            <span :class="`inline-block px-3 py-1 ${item.color} text-white rounded-full text-xs font-bold`">{{ item.grade }}</span>
-                        </td>
-                        <td class="py-3 px-4 text-slate-300 text-xs">{{ item.edu }}</td>
-                        <td class="py-3 px-4 text-slate-300 text-xs">{{ item.cert }}</td>
-                    </tr>
-                </tbody>
-            </table>
+        <!-- Right Column: Result & Info -->
+        <div class="lg:col-span-5 space-y-6 animate-fade-in-up" style="animation-delay: 100ms;">
+            <!-- Result Card -->
+            <div
+                class="relative rounded-3xl p-8 text-center min-h-[360px] flex flex-col items-center justify-center transition-all duration-500 shadow-xl overflow-hidden border border-white/10"
+                :class="calculatedGrade 
+                    ? `bg-gradient-to-br ${getGradeColor(calculatedGrade)}` 
+                    : 'bg-white/5 border-white/10'"
+            >
+                <!-- Background Pattern -->
+                <div v-if="calculatedGrade" class="absolute inset-0 bg-[url('@/assets/noise.png')] opacity-20 mix-blend-overlay"></div>
+                <div v-if="calculatedGrade" class="absolute -top-20 -right-20 w-64 h-64 bg-white/20 rounded-full blur-3xl"></div>
+                <div v-if="calculatedGrade" class="absolute -bottom-20 -left-20 w-64 h-64 bg-black/20 rounded-full blur-3xl"></div>
+
+                <template v-if="calculatedGrade">
+                    <div class="relative z-10 animate-fade-in-up">
+                        <div class="mb-4 inline-flex p-4 bg-white/20 backdrop-blur-md rounded-full ring-4 ring-white/10 shadow-inner">
+                            <CheckCircle class="w-10 h-10 text-white" />
+                        </div>
+                        <div class="text-sm font-medium text-white/90 mb-1 tracking-wide uppercase">Calculated Grade</div>
+                        <div class="text-6xl font-black text-white mb-2 drop-shadow-md">{{ calculatedGrade }}</div>
+                        <div class="text-base text-white/80 font-medium mb-8">등급에 해당합니다</div>
+                        
+                        <div class="bg-black/20 backdrop-blur-md rounded-xl p-4 text-left border border-white/10 mb-8 max-w-xs mx-auto">
+                            <div class="flex items-start gap-3">
+                                <Info class="w-5 h-5 text-white/60 shrink-0 mt-0.5" />
+                                <p class="text-xs text-white/70 leading-relaxed">
+                                    이 결과는 입력하신 정보를 바탕으로 산출된 예상 등급입니다. 실제 증빙 서류에 따라 달라질 수 있습니다.
+                                </p>
+                            </div>
+                        </div>
+
+                         <button
+                            @click="handleSave"
+                            :disabled="isSaving"
+                            class="w-full px-6 py-3 bg-white hover:bg-slate-100 text-slate-900 rounded-xl font-bold transition-all flex items-center justify-center gap-2 shadow-lg hover:shadow-xl hover:-translate-y-0.5"
+                        >
+                            <Loader2 v-if="isSaving" class="w-4 h-4 animate-spin text-slate-900" />
+                            <Save v-else class="w-4 h-4 text-slate-900" />
+                            등급 정보 저장하기
+                        </button>
+                    </div>
+                </template>
+
+                 <template v-else>
+                    <div class="text-slate-500 flex flex-col items-center">
+                        <div class="w-20 h-20 rounded-full bg-white/5 flex items-center justify-center mb-4">
+                            <Award class="w-10 h-10 text-slate-600" />
+                        </div>
+                        <p class="text-lg font-bold text-slate-400">등급을 계산해보세요</p>
+                        <p class="text-sm text-slate-500 mt-2">왼쪽에서 정보를 입력하면<br>결과가 표시됩니다.</p>
+                    </div>
+                </template>
+            </div>
+
+            <!-- Warning Card -->
+            <div class="bg-red-500/10 border border-red-500/20 rounded-3xl p-6 relative overflow-hidden">
+                <div class="absolute -right-4 -top-4 w-24 h-24 bg-red-500/20 rounded-full blur-2xl"></div>
+                <h4 class="text-red-400 font-bold flex items-center gap-2 mb-3 relative z-10">
+                    <Info class="w-5 h-5" />
+                    허위 정보 입력 시 주의사항
+                </h4>
+                <p class="text-sm text-red-200/70 leading-relaxed relative z-10">
+                    입력하신 정보가 허위로 판명될 경우, 프리랜서 이용 약관에 따라 <span class="text-red-300 font-bold underline decoration-red-500/50 decoration-2 underline-offset-2">계정 정지 또는 법적 책임</span>을 물을 수 있습니다. 반드시 사실에 근거한 정보를 입력해 주세요.
+                </p>
+            </div>
         </div>
     </div>
   </div>

--- a/freebridgefe/src/views/freelancer/MyPage/components/GradeCheckPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/GradeCheckPage.vue
@@ -329,7 +329,7 @@ const getGradeBadgeColor = (grade: string) => {
                     : 'bg-white/5 border-white/10'"
             >
                 <!-- Background Pattern -->
-                <div v-if="calculatedGrade" class="absolute inset-0 bg-[url('@/assets/noise.png')] opacity-20 mix-blend-overlay"></div>
+
                 <div v-if="calculatedGrade" class="absolute -top-20 -right-20 w-64 h-64 bg-white/20 rounded-full blur-3xl"></div>
                 <div v-if="calculatedGrade" class="absolute -bottom-20 -left-20 w-64 h-64 bg-black/20 rounded-full blur-3xl"></div>
 

--- a/freebridgefe/src/views/freelancer/MyPage/components/ProfileEditPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/ProfileEditPage.vue
@@ -128,7 +128,7 @@ const saveProfile = async () => {
                         </div>
                          <div class="space-y-1">
                             <label class="text-xs text-slate-400 font-bold">희망 시급 (시간당)</label>
-                            <input v-model="formData.salary" type="number" placeholder="ex) 50000" class="w-full bg-slate-900 border border-white/10 rounded-lg px-4 py-2 text-white text-sm focus:border-blue-500 focus:outline-none" />
+                            <input v-model.number="formData.salary" type="number" placeholder="ex) 50000" class="w-full bg-slate-900 border border-white/10 rounded-lg px-4 py-2 text-white text-sm focus:border-blue-500 focus:outline-none" />
                         </div>
                     </div>
 

--- a/freebridgefe/src/views/freelancer/MyPage/components/ProfileEditPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/ProfileEditPage.vue
@@ -127,8 +127,8 @@ const saveProfile = async () => {
                             <input v-model.number="formData.careerYears" type="number" class="w-full bg-slate-900 border border-white/10 rounded-lg px-4 py-2 text-white text-sm focus:border-blue-500 focus:outline-none" />
                         </div>
                          <div class="space-y-1">
-                            <label class="text-xs text-slate-400 font-bold">희망 평균 단가 (월)</label>
-                            <input v-model="formData.salary" type="text" placeholder="ex) 월 800만원" class="w-full bg-slate-900 border border-white/10 rounded-lg px-4 py-2 text-white text-sm focus:border-blue-500 focus:outline-none" />
+                            <label class="text-xs text-slate-400 font-bold">희망 시급 (시간당)</label>
+                            <input v-model="formData.salary" type="number" placeholder="ex) 50000" class="w-full bg-slate-900 border border-white/10 rounded-lg px-4 py-2 text-white text-sm focus:border-blue-500 focus:outline-none" />
                         </div>
                     </div>
 

--- a/freebridgefe/src/views/freelancer/MyPage/components/ProjectManagementPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/ProjectManagementPage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue';
-import { Search, Filter, Calendar, DollarSign, User as UserIcon, ArrowLeft } from 'lucide-vue-next';
-import { getFreelancerProjects, type FreelancerProject } from '@/api/MyPage/projectApi.ts';
+import { Search, Calendar, DollarSign, User as UserIcon, ArrowLeft } from 'lucide-vue-next';
+import { getFreelancerProjects, type FreelancerProject } from '@/api/MyPage/projectApi';
 import { useAuthStore } from '@/stores/authStore';
 
 const authStore = useAuthStore();
@@ -99,9 +99,7 @@ const getStatusLabel = (status: string) => {
                         class="bg-[#1e293b] border border-white/10 rounded-lg pl-10 pr-4 py-2 text-sm text-white focus:outline-none focus:border-blue-500 w-64"
                     />
                 </div>
-                <button class="p-2 bg-[#1e293b] border border-white/10 rounded-lg text-slate-400 hover:text-white hover:border-white/30 transition-colors">
-                    <Filter class="w-4 h-4" />
-                </button>
+
             </div>
         </div>
 

--- a/freebridgefe/src/views/freelancer/MyPage/components/ResumeManagementPage.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/ResumeManagementPage.vue
@@ -14,7 +14,9 @@ import {
     Trash2,
     Briefcase,
     Award,
-    Check
+    Check,
+    X,
+    Loader2
 } from 'lucide-vue-next';
 import {
     getResumeDetail,
@@ -46,6 +48,7 @@ const resumeData = ref<ResumeDetail>({
 });
 
 const isLoading = ref(true);
+const isSaving = ref(false);
 
 // --- Temporary State for Adding Items ---
 const isAddingEducation = ref(false);
@@ -85,7 +88,7 @@ const newCertification = ref<Certification>({
 onMounted(async () => {
     try {
         isLoading.value = true;
-        resumeData.value = await getResumeDetail(authStore.user?.id || 1);
+        resumeData.value = await getResumeDetail(Number(authStore.user?.id) || 1);
     } catch (e) {
         console.error(e);
         alert('이력서 데이터를 불러오는데 실패했습니다.');
@@ -96,12 +99,15 @@ onMounted(async () => {
 
 const handleSave = async () => {
     try {
+        isSaving.value = true;
         const success = await saveResumeDetail(resumeData.value);
         if (success) {
-            alert('이력서 정보가 저장되었습니다.');
+            alert('이력서 정보가 성공적으로 저장되었습니다.');
         }
     } catch (e) {
         alert('저장 중 오류가 발생했습니다.');
+    } finally {
+        isSaving.value = false;
     }
 };
 
@@ -124,7 +130,7 @@ const addEducation = () => {
 };
 
 const removeEducation = (index: number) => {
-    if (confirm('삭제하시겠습니까?')) {
+    if (confirm('해당 학력 정보를 삭제하시겠습니까?')) {
         resumeData.value.educations.splice(index, 1);
     }
 };
@@ -150,7 +156,7 @@ const addCareer = () => {
 };
 
 const removeCareer = (index: number) => {
-    if (confirm('삭제하시겠습니까?')) {
+    if (confirm('해당 경력 정보를 삭제하시겠습니까?')) {
         resumeData.value.careers.splice(index, 1);
     }
 };
@@ -171,341 +177,391 @@ const addCertification = () => {
 };
 
 const removeCertification = (index: number) => {
-    if (confirm('삭제하시겠습니까?')) {
+    if (confirm('해당 자격증 정보를 삭제하시겠습니까?')) {
         resumeData.value.certifications.splice(index, 1);
     }
 };
 </script>
 
 <template>
-    <div class="max-w-5xl mx-auto px-4 md:px-8 py-8 font-sans text-white">
+    <div class="max-w-7xl mx-auto px-4 md:px-8 py-10 font-sans text-white">
         <!-- Header -->
-        <div class="flex items-center justify-between mb-8">
+        <div class="flex items-center justify-between mb-10">
             <div class="flex items-center gap-4">
                 <button
                     @click="$emit('back')"
-                    class="p-2 hover:bg-white/5 rounded-lg transition-colors"
-                    v-motion
-                    :hover="{ scale: 1.1 }"
-                    :tap="{ scale: 0.9 }"
+                    class="p-2 hover:bg-white/5 rounded-full transition-colors"
                 >
-                    <ArrowLeft class="w-5 h-5 text-white/60" />
+                    <ArrowLeft class="w-6 h-6 text-white/80" />
                 </button>
                 <div>
-                    <h1 class="text-2xl font-bold text-white">이력서 상세 관리</h1>
-                    <p class="text-sm text-slate-400 mt-1">기본 정보와 상세 경력을 관리하세요.</p>
+                    <h1 class="text-3xl font-bold text-white tracking-tight">이력서 상세 관리</h1>
+                    <p class="text-base text-slate-400 mt-1">기본 정보와 상세 경력을 관리하여 매력을 어필하세요.</p>
                 </div>
             </div>
             <button
                 @click="handleSave"
-                class="px-6 py-2.5 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-bold transition-colors flex items-center gap-2 shadow-lg shadow-blue-500/20"
+                :disabled="isSaving"
+                class="px-6 py-2.5 bg-blue-600 hover:bg-blue-500 disabled:bg-blue-600/50 text-white rounded-xl font-bold transition-all flex items-center gap-2 shadow-lg shadow-blue-500/20"
             >
-                <Save class="w-4 h-4" />
-                저장하기
+                <Loader2 v-if="isSaving" class="w-4 h-4 animate-spin" />
+                <Save v-else class="w-4 h-4" />
+                <span>{{ isSaving ? '저장 중...' : '저장하기' }}</span>
             </button>
         </div>
 
-        <div v-if="isLoading" class="flex justify-center py-20">
-            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-white"></div>
+        <!-- Loading State -->
+        <div v-if="isLoading" class="flex justify-center py-40">
+            <Loader2 class="w-10 h-10 animate-spin text-white/50" />
         </div>
 
-        <div v-else class="space-y-6">
+        <div v-else class="space-y-8 animate-fade-in-up">
             <!-- 1. 기본 정보 (Basic Info) -->
-            <div class="bg-white/5 rounded-2xl border border-white/10 p-8">
-                <h2 class="text-lg font-bold text-white mb-6 flex items-center gap-2">
-                    <User class="w-5 h-5 text-blue-400" />
+            <section class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-sm">
+                <h2 class="text-xl font-bold text-white mb-6 flex items-center gap-2">
+                    <div class="p-2 bg-blue-500/10 rounded-lg">
+                        <User class="w-5 h-5 text-blue-400" />
+                    </div>
                     기본 정보
                 </h2>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div>
-                        <label class="text-xs text-slate-500 mb-1.5 block">이름</label>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">이름</label>
                         <input
                             type="text"
                             v-model="resumeData.name"
-                            class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2.5 text-white text-sm outline-none focus:border-blue-500/50 transition-colors"
+                            class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl px-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
+                            placeholder="이름 입력"
                         />
                     </div>
-                    <div>
-                        <label class="text-xs text-slate-500 mb-1.5 block">생년월일</label>
-                        <div class="relative">
-                            <input
-                                type="date"
-                                v-model="resumeData.birthDate"
-                                class="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2.5 text-white text-sm outline-none focus:border-blue-500/50 transition-colors"
-                            />
-                            <!-- Custom Calendar Icon overlay could go here if needed -->
-                        </div>
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">생년월일</label>
+                        <input
+                            type="date"
+                            v-model="resumeData.birthDate"
+                            class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl px-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
+                        />
                     </div>
-                    <div>
-                        <label class="text-xs text-slate-500 mb-1.5 block">연락처</label>
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">연락처</label>
                         <div class="relative">
-                            <Phone class="w-4 h-4 text-slate-500 absolute left-3 top-3" />
+                            <Phone class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
                             <input
                                 type="tel"
                                 v-model="resumeData.phone"
-                                class="w-full bg-white/5 border border-white/10 rounded-lg pl-10 pr-4 py-2.5 text-white text-sm outline-none focus:border-blue-500/50 transition-colors"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
                                 placeholder="010-0000-0000"
                             />
                         </div>
                     </div>
-                    <div>
-                        <label class="text-xs text-slate-500 mb-1.5 block">이메일</label>
+                    <div class="space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">이메일</label>
                         <div class="relative">
-                            <Mail class="w-4 h-4 text-slate-500 absolute left-3 top-3" />
+                            <Mail class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
                             <input
                                 type="email"
                                 v-model="resumeData.email"
-                                class="w-full bg-white/5 border border-white/10 rounded-lg pl-10 pr-4 py-2.5 text-white text-sm outline-none focus:border-blue-500/50 transition-colors"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
+                                placeholder="example@email.com"
                             />
                         </div>
                     </div>
-                    <div class="md:col-span-2">
-                        <label class="text-xs text-slate-500 mb-1.5 block">주소</label>
+                    <div class="md:col-span-2 space-y-2">
+                        <label class="text-xs text-slate-400 font-bold ml-1">주소</label>
                         <div class="relative">
-                            <MapPin class="w-4 h-4 text-slate-500 absolute left-3 top-3" />
+                            <MapPin class="w-4 h-4 text-slate-500 absolute left-4 top-3.5" />
                             <input
                                 type="text"
                                 v-model="resumeData.address"
-                                class="w-full bg-white/5 border border-white/10 rounded-lg pl-10 pr-4 py-2.5 text-white text-sm outline-none focus:border-blue-500/50 transition-colors"
+                                class="w-full bg-[#1e293b]/50 border border-white/10 rounded-xl pl-11 pr-4 py-3 text-white text-sm outline-none focus:border-blue-500/50 focus:bg-[#1e293b] transition-all"
+                                placeholder="주소 입력"
                             />
                         </div>
                     </div>
                 </div>
-            </div>
+            </section>
 
             <!-- 2. 학력 사항 (Education) -->
-            <div class="bg-white/5 rounded-2xl border border-white/10 p-8">
+            <section class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-sm">
                 <div class="flex items-center justify-between mb-6">
-                    <h2 class="text-lg font-bold text-white flex items-center gap-2">
-                        <GraduationCap class="w-5 h-5 text-green-400" />
+                    <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                         <div class="p-2 bg-green-500/10 rounded-lg">
+                            <GraduationCap class="w-5 h-5 text-green-400" />
+                        </div>
                         학력 사항
                     </h2>
                     <button 
                         v-if="!isAddingEducation"
                         @click="isAddingEducation = true"
-                        class="text-xs bg-white/5 hover:bg-white/10 px-3 py-1.5 rounded-lg text-slate-300 transition-colors flex items-center gap-1"
+                        class="px-4 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-sm text-slate-300 hover:text-white transition-all flex items-center gap-2"
                     >
-                        <Plus class="w-3 h-3" /> 추가
+                        <Plus class="w-4 h-4" /> 항목 추가
                     </button>
                 </div>
 
-                <!-- Education List -->
-                <div class="space-y-3 mb-4">
+                <!-- List -->
+                <div class="space-y-4">
                     <div 
                         v-for="(edu, index) in resumeData.educations" 
                         :key="edu.id" 
-                        class="bg-white/5 p-5 rounded-xl border border-white/5 flex flex-col md:flex-row md:items-center justify-between gap-4 group hover:border-white/10 transition-colors"
+                        class="group bg-[#1e293b]/30 hover:bg-[#1e293b]/60 border border-white/5 rounded-2xl p-6 transition-all"
                     >
-                        <div class="flex-1">
-                            <div class="flex items-center gap-2 mb-1">
-                                <span class="text-xs px-2 py-0.5 rounded bg-green-500/20 text-green-400 border border-green-500/20">{{ edu.schoolType }}</span>
-                                <span class="text-xs text-slate-500">{{ edu.status }}</span>
+                        <div class="flex flex-col md:flex-row md:items-center justify-between gap-4">
+                            <div class="flex-1">
+                                <div class="flex items-center gap-3 mb-2">
+                                    <span class="text-xs px-2 py-0.5 rounded-md bg-green-500/10 text-green-400 border border-green-500/20 font-bold">{{ edu.schoolType }}</span>
+                                    <span class="text-xs text-slate-500 px-2 py-0.5 rounded-md bg-white/5">{{ edu.status }}</span>
+                                </div>
+                                <h3 class="font-bold text-white text-lg">{{ edu.schoolName }}</h3>
+                                <p class="text-sm text-slate-400 mt-1">{{ edu.major }}</p>
                             </div>
-                            <h3 class="font-bold text-white text-lg">{{ edu.schoolName }}</h3>
-                            <p class="text-sm text-slate-400">{{ edu.major }}</p>
-                        </div>
-                        <div class="flex items-center gap-4">
-                            <span class="text-sm text-slate-500 font-mono">{{ edu.entranceDate }} ~ {{ edu.graduationDate }}</span>
-                            <button @click="removeEducation(index)" class="p-2 text-slate-600 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors opacity-0 group-hover:opacity-100">
-                                <Trash2 class="w-4 h-4" />
-                            </button>
+                            <div class="flex items-center gap-6">
+                                <span class="text-sm text-slate-500 font-mono bg-black/20 px-3 py-1 rounded-lg">{{ edu.entranceDate }} ~ {{ edu.graduationDate }}</span>
+                                <button 
+                                    @click="removeEducation(index)" 
+                                    class="p-2 text-slate-600 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+                                    title="삭제"
+                                >
+                                    <Trash2 class="w-5 h-5" />
+                                </button>
+                            </div>
                         </div>
                     </div>
-                </div>
 
-                <!-- Add Education Form -->
-                <div v-if="isAddingEducation" class="bg-white/5 p-5 rounded-xl border border-green-500/30 animate-in fade-in slide-in-from-top-2">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                        <div>
-                            <label class="text-xs text-slate-500 mb-1 block">학교 구분</label>
-                            <select v-model="newEducation.schoolType" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none">
-                                <option value="고등학교">고등학교</option>
-                                <option value="대학교">대학교</option>
-                                <option value="대학원">대학원</option>
-                            </select>
+                    <!-- Add Form -->
+                    <div v-if="isAddingEducation" class="bg-[#1e293b]/50 border border-green-500/30 rounded-2xl p-6 animate-fade-in-down">
+                        <div class="flex items-center justify-between mb-4">
+                            <h3 class="text-sm font-bold text-green-400">새 학력 추가</h3>
+                            <button @click="isAddingEducation = false" class="text-slate-500 hover:text-white"><X class="w-4 h-4" /></button>
                         </div>
-                        <div>
-                            <label class="text-xs text-slate-500 mb-1 block">학교명</label>
-                            <input type="text" v-model="newEducation.schoolName" placeholder="학교명 입력" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
-                        </div>
-                        <div>
-                            <label class="text-xs text-slate-500 mb-1 block">전공</label>
-                            <input type="text" v-model="newEducation.major" placeholder="전공 입력" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
-                        </div>
-                        <div>
-                            <label class="text-xs text-slate-500 mb-1 block">상태</label>
-                            <select v-model="newEducation.status" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none">
-                                <option value="졸업">졸업</option>
-                                <option value="재학">재학</option>
-                                <option value="수료">수료</option>
-                                <option value="휴학">휴학</option>
-                            </select>
-                        </div>
-                        <div class="grid grid-cols-2 gap-2">
-                            <div>
-                                <label class="text-xs text-slate-500 mb-1 block">입학년월</label>
-                                <input type="text" v-model="newEducation.entranceDate" placeholder="YYYY.MM" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+                            <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">학교 구분</label>
+                                <select v-model="newEducation.schoolType" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none">
+                                    <option value="고등학교">고등학교</option>
+                                    <option value="대학교">대학교</option>
+                                    <option value="대학원">대학원</option>
+                                </select>
                             </div>
-                            <div>
-                                <label class="text-xs text-slate-500 mb-1 block">졸업년월</label>
-                                <input type="text" v-model="newEducation.graduationDate" placeholder="YYYY.MM" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
+                            <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">학교명</label>
+                                <input type="text" v-model="newEducation.schoolName" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" placeholder="예: 한국대학교" />
+                            </div>
+                            <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">전공</label>
+                                <input type="text" v-model="newEducation.major" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" placeholder="예: 컴퓨터공학과" />
+                            </div>
+                            <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">상태</label>
+                                <select v-model="newEducation.status" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none">
+                                    <option value="졸업">졸업</option>
+                                    <option value="재학">재학</option>
+                                    <option value="수료">수료</option>
+                                    <option value="휴학">휴학</option>
+                                </select>
+                            </div>
+                            <div class="grid grid-cols-2 gap-2">
+                                <div class="space-y-1">
+                                    <label class="text-xs text-slate-500 ml-1">입학년월</label>
+                                    <input type="text" v-model="newEducation.entranceDate" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" placeholder="YYYY.MM" />
+                                </div>
+                                <div class="space-y-1">
+                                    <label class="text-xs text-slate-500 ml-1">졸업년월</label>
+                                    <input type="text" v-model="newEducation.graduationDate" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" placeholder="YYYY.MM" />
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="flex justify-end gap-2">
-                        <button @click="isAddingEducation = false" class="px-3 py-1.5 text-xs text-slate-400 hover:text-white">취소</button>
-                        <button @click="addEducation" class="px-3 py-1.5 bg-green-600 hover:bg-green-500 text-white text-xs rounded-lg font-bold">추가 완료</button>
+                        <div class="flex justify-end gap-2">
+                            <button @click="isAddingEducation = false" class="px-4 py-2 text-sm text-slate-400 hover:text-white transition-colors">취소</button>
+                            <button @click="addEducation" class="px-4 py-2 bg-green-600 hover:bg-green-500 text-white text-sm rounded-lg font-bold transition-colors">추가 완료</button>
+                        </div>
                     </div>
                 </div>
-            </div>
+            </section>
 
             <!-- 3. 경력 사항 (Career) -->
-            <div class="bg-white/5 rounded-2xl border border-white/10 p-8">
+            <section class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-sm">
                 <div class="flex items-center justify-between mb-6">
-                    <h2 class="text-lg font-bold text-white flex items-center gap-2">
-                        <Briefcase class="w-5 h-5 text-orange-400" />
+                    <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                        <div class="p-2 bg-orange-500/10 rounded-lg">
+                            <Briefcase class="w-5 h-5 text-orange-400" />
+                        </div>
                         경력 사항
                     </h2>
                     <button 
                         v-if="!isAddingCareer"
                         @click="isAddingCareer = true"
-                        class="text-xs bg-white/5 hover:bg-white/10 px-3 py-1.5 rounded-lg text-slate-300 transition-colors flex items-center gap-1"
+                        class="px-4 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-sm text-slate-300 hover:text-white transition-all flex items-center gap-2"
                     >
-                        <Plus class="w-3 h-3" /> 추가
+                        <Plus class="w-4 h-4" /> 항목 추가
                     </button>
                 </div>
 
-                <div class="space-y-4 mb-4">
+                <div class="space-y-6">
                     <div 
                         v-for="(career, index) in resumeData.careers" 
                         :key="career.id" 
-                        class="relative pl-6 pb-4 border-l-2 border-white/10 last:border-0 last:pb-0 group"
+                        class="relative pl-8 group"
                     >
-                        <div class="absolute -left-[9px] top-0 w-4 h-4 rounded-full bg-orange-500 border-4 border-[#1e293b]"></div>
-                        <div class="flex justify-between items-start">
-                            <div>
-                                <h3 class="font-bold text-white text-lg mb-0.5">{{ career.companyName }}</h3>
-                                <p class="text-sm text-orange-400 mb-2">{{ career.department }} / {{ career.position }} ({{ career.employmentType }})</p>
-                                <p class="text-sm text-slate-300">{{ career.jobType }}</p>
-                                <p class="text-xs text-slate-500 mt-2 leading-relaxed">{{ career.description }}</p>
-                            </div>
-                            <div class="flex flex-col items-end gap-2">
-                                <span class="text-xs text-slate-500 bg-white/5 px-2 py-1 rounded">{{ career.startDate }} ~ {{ career.endDate }}</span>
-                                <button @click="removeCareer(index)" class="p-1.5 text-slate-600 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity">
-                                    <Trash2 class="w-4 h-4" />
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                        <!-- Timeline Line -->
+                        <div class="absolute left-[11px] top-8 bottom-0 w-0.5 bg-white/10 group-last:hidden"></div>
+                        <!-- Dot -->
+                        <div class="absolute left-0 top-1.5 w-6 h-6 rounded-full bg-[#1e293b] border-2 border-orange-500 z-10"></div>
 
-                <!-- Add Career Form -->
-                <div v-if="isAddingCareer" class="bg-white/5 p-5 rounded-xl border border-orange-500/30 animate-in fade-in slide-in-from-top-2">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                        <div class="col-span-1 md:col-span-2">
-                            <label class="text-xs text-slate-500 mb-1 block">회사명</label>
-                            <input type="text" v-model="newCareer.companyName" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
-                        </div>
-                        <div>
-                            <label class="text-xs text-slate-500 mb-1 block">부서</label>
-                            <input type="text" v-model="newCareer.department" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
-                        </div>
-                         <div>
-                            <label class="text-xs text-slate-500 mb-1 block">직위/직책</label>
-                            <input type="text" v-model="newCareer.position" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
-                        </div>
-                        <div>
-                            <label class="text-xs text-slate-500 mb-1 block">고용 형태</label>
-                            <select v-model="newCareer.employmentType" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none">
-                                <option value="정규직">정규직</option>
-                                <option value="계약직">계약직</option>
-                                <option value="프리랜서">프리랜서</option>
-                                <option value="인턴">인턴</option>
-                            </select>
-                        </div>
-                         <div>
-                            <label class="text-xs text-slate-500 mb-1 block">담당 업무</label>
-                            <input type="text" v-model="newCareer.jobType" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
-                        </div>
-                        <div class="grid grid-cols-2 gap-2">
-                            <div>
-                                <label class="text-xs text-slate-500 mb-1 block">입사년월</label>
-                                <input type="text" v-model="newCareer.startDate" placeholder="YYYY.MM" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
+                        <div class="bg-[#1e293b]/30 hover:bg-[#1e293b]/60 border border-white/5 rounded-2xl p-6 transition-all relative">
+                             <div class="flex justify-between items-start mb-4">
+                                <div>
+                                    <h3 class="font-bold text-white text-lg">{{ career.companyName }}</h3>
+                                    <div class="flex items-center gap-2 mt-1 text-sm">
+                                        <span class="text-orange-400 font-bold">{{ career.position }}</span>
+                                        <span class="text-slate-600">|</span>
+                                        <span class="text-slate-400">{{ career.department }}</span>
+                                        <span class="text-slate-600">|</span>
+                                        <span class="text-xs px-1.5 py-0.5 rounded bg-white/5 text-slate-400">{{ career.employmentType }}</span>
+                                    </div>
+                                </div>
+                                <div class="flex items-center gap-4">
+                                    <span class="text-sm text-slate-500 font-mono bg-black/20 px-3 py-1 rounded-lg">{{ career.startDate }} ~ {{ career.endDate }}</span>
+                                    <button 
+                                        @click="removeCareer(index)" 
+                                        class="p-2 text-slate-600 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+                                    >
+                                        <Trash2 class="w-5 h-5" />
+                                    </button>
+                                </div>
                             </div>
-                            <div>
-                                <label class="text-xs text-slate-500 mb-1 block">퇴사년월</label>
-                                <input type="text" v-model="newCareer.endDate" placeholder="YYYY.MM or 재직중" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
+                            
+                            <div class="bg-black/20 rounded-xl p-4 border border-white/5">
+                                <p class="text-sm text-slate-300 leading-relaxed whitespace-pre-wrap">{{ career.description }}</p>
+                                <div class="mt-3 pt-3 border-t border-white/5 flex items-center gap-2">
+                                     <span class="text-xs text-slate-500 font-bold">담당 업무:</span>
+                                     <span class="text-xs text-slate-400">{{ career.jobType }}</span>
+                                </div>
                             </div>
-                        </div>
-                        <div class="col-span-1 md:col-span-2">
-                             <label class="text-xs text-slate-500 mb-1 block">상세 설명</label>
-                             <textarea v-model="newCareer.description" rows="3" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none resize-none"></textarea>
                         </div>
                     </div>
-                    <div class="flex justify-end gap-2">
-                        <button @click="isAddingCareer = false" class="px-3 py-1.5 text-xs text-slate-400 hover:text-white">취소</button>
-                        <button @click="addCareer" class="px-3 py-1.5 bg-orange-600 hover:bg-orange-500 text-white text-xs rounded-lg font-bold">추가 완료</button>
+
+                    <!-- Add Form -->
+                    <div v-if="isAddingCareer" class="bg-[#1e293b]/50 border border-orange-500/30 rounded-2xl p-6 animate-fade-in-down ml-8">
+                         <div class="flex items-center justify-between mb-4">
+                            <h3 class="text-sm font-bold text-orange-400">새 경력 추가</h3>
+                            <button @click="isAddingCareer = false" class="text-slate-500 hover:text-white"><X class="w-4 h-4" /></button>
+                        </div>
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                            <div class="col-span-1 md:col-span-2 space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">회사명</label>
+                                <input type="text" v-model="newCareer.companyName" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" />
+                            </div>
+                            <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">부서</label>
+                                <input type="text" v-model="newCareer.department" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" />
+                            </div>
+                             <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">직위/직책</label>
+                                <input type="text" v-model="newCareer.position" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" />
+                            </div>
+                            <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">고용 형태</label>
+                                <select v-model="newCareer.employmentType" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none">
+                                    <option value="정규직">정규직</option>
+                                    <option value="계약직">계약직</option>
+                                    <option value="프리랜서">프리랜서</option>
+                                    <option value="인턴">인턴</option>
+                                </select>
+                            </div>
+                             <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">담당 업무 키워드</label>
+                                <input type="text" v-model="newCareer.jobType" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" placeholder="예: 백엔드 개발" />
+                            </div>
+                            <div class="grid grid-cols-2 gap-2">
+                                <div class="space-y-1">
+                                    <label class="text-xs text-slate-500 ml-1">입사년월</label>
+                                    <input type="text" v-model="newCareer.startDate" placeholder="YYYY.MM" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" />
+                                </div>
+                                <div class="space-y-1">
+                                    <label class="text-xs text-slate-500 ml-1">퇴사년월</label>
+                                    <input type="text" v-model="newCareer.endDate" placeholder="YYYY.MM or 재직중" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" />
+                                </div>
+                            </div>
+                            <div class="col-span-1 md:col-span-2 space-y-1">
+                                 <label class="text-xs text-slate-500 ml-1">상세 설명</label>
+                                 <textarea v-model="newCareer.description" rows="3" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none resize-none" placeholder="주요 성과 및 업무 내용을 기술해주세요."></textarea>
+                            </div>
+                        </div>
+                        <div class="flex justify-end gap-2">
+                            <button @click="isAddingCareer = false" class="px-4 py-2 text-sm text-slate-400 hover:text-white transition-colors">취소</button>
+                            <button @click="addCareer" class="px-4 py-2 bg-orange-600 hover:bg-orange-500 text-white text-sm rounded-lg font-bold transition-colors">추가 완료</button>
+                        </div>
                     </div>
                 </div>
-            </div>
+            </section>
 
             <!-- 4. 자격증 (Certifications) -->
-            <div class="bg-white/5 rounded-2xl border border-white/10 p-8">
+            <section class="bg-white/5 border border-white/10 rounded-3xl p-8 backdrop-blur-sm">
                <div class="flex items-center justify-between mb-6">
-                    <h2 class="text-lg font-bold text-white flex items-center gap-2">
-                        <Award class="w-5 h-5 text-yellow-400" />
+                    <h2 class="text-xl font-bold text-white flex items-center gap-2">
+                        <div class="p-2 bg-yellow-500/10 rounded-lg">
+                            <Award class="w-5 h-5 text-yellow-400" />
+                        </div>
                         자격증
                     </h2>
                     <button 
                         v-if="!isAddingCertification"
                         @click="isAddingCertification = true"
-                        class="text-xs bg-white/5 hover:bg-white/10 px-3 py-1.5 rounded-lg text-slate-300 transition-colors flex items-center gap-1"
+                        class="px-4 py-2 bg-white/5 hover:bg-white/10 rounded-lg text-sm text-slate-300 hover:text-white transition-all flex items-center gap-2"
                     >
-                        <Plus class="w-3 h-3" /> 추가
+                        <Plus class="w-4 h-4" /> 항목 추가
                     </button>
                 </div>
 
-                <div class="space-y-3 mb-4">
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                     <div 
                         v-for="(cert, index) in resumeData.certifications" 
                         :key="cert.id" 
-                        class="bg-white/5 p-4 rounded-xl border border-white/5 flex items-center justify-between group hover:border-white/10"
+                        class="bg-[#1e293b]/30 hover:bg-[#1e293b]/60 border border-white/5 rounded-2xl p-6 transition-all group flex flex-col justify-between"
                     >
                         <div>
-                            <h3 class="font-bold text-white">{{ cert.name }}</h3>
-                            <p class="text-sm text-slate-400">{{ cert.issuer }}</p>
+                            <div class="flex items-center justify-between mb-2">
+                                <Award class="w-8 h-8 text-yellow-500/50" />
+                                <button @click="removeCertification(index)" class="text-slate-600 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity">
+                                    <Trash2 class="w-4 h-4" />
+                                </button>
+                            </div>
+                            <h3 class="font-bold text-white text-lg leading-tight">{{ cert.name }}</h3>
+                            <p class="text-sm text-slate-400 mt-1">{{ cert.issuer }}</p>
                         </div>
-                        <div class="flex items-center gap-4">
-                            <span class="text-sm text-slate-500 font-mono">{{ cert.acquisitionDate }}</span>
-                            <button @click="removeCertification(index)" class="p-2 text-slate-600 hover:text-red-400 hover:bg-red-400/10 rounded-lg transition-colors opacity-0 group-hover:opacity-100">
-                                <Trash2 class="w-4 h-4" />
-                            </button>
+                        <div class="mt-4 pt-4 border-t border-white/5 text-xs text-slate-500 font-mono">
+                            취득일: {{ cert.acquisitionDate }}
                         </div>
                     </div>
-                </div>
 
-                <!-- Add Certification Form -->
-                <div v-if="isAddingCertification" class="bg-white/5 p-5 rounded-xl border border-yellow-500/30 animate-in fade-in slide-in-from-top-2">
-                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-                        <div>
-                            <label class="text-xs text-slate-500 mb-1 block">자격증명</label>
-                            <input type="text" v-model="newCertification.name" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
+                    <!-- Add Form Card -->
+                    <div v-if="isAddingCertification" class="col-span-1 md:col-span-2 lg:col-span-3 bg-[#1e293b]/50 border border-yellow-500/30 rounded-2xl p-6 animate-fade-in">
+                         <div class="flex items-center justify-between mb-4">
+                            <h3 class="text-sm font-bold text-yellow-400">새 자격증 추가</h3>
+                            <button @click="isAddingCertification = false" class="text-slate-500 hover:text-white"><X class="w-4 h-4" /></button>
                         </div>
-                        <div>
-                            <label class="text-xs text-slate-500 mb-1 block">발급기관</label>
-                            <input type="text" v-model="newCertification.issuer" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+                            <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">자격증명</label>
+                                <input type="text" v-model="newCertification.name" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" />
+                            </div>
+                            <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">발급기관</label>
+                                <input type="text" v-model="newCertification.issuer" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" />
+                            </div>
+                            <div class="space-y-1">
+                                <label class="text-xs text-slate-500 ml-1">취득년월</label>
+                                <input type="text" v-model="newCertification.acquisitionDate" placeholder="YYYY.MM" class="w-full bg-[#0F172A] border border-white/10 rounded-lg px-3 py-2.5 text-white text-sm outline-none" />
+                            </div>
                         </div>
-                        <div>
-                            <label class="text-xs text-slate-500 mb-1 block">취득년월</label>
-                            <input type="text" v-model="newCertification.acquisitionDate" placeholder="YYYY.MM" class="w-full bg-[#1e293b] border border-white/10 rounded-lg px-3 py-2 text-white text-sm outline-none" />
+                        <div class="flex justify-end gap-2">
+                             <button @click="isAddingCertification = false" class="px-4 py-2 text-sm text-slate-400 hover:text-white transition-colors">취소</button>
+                            <button @click="addCertification" class="px-4 py-2 bg-yellow-600 hover:bg-yellow-500 text-white text-sm rounded-lg font-bold transition-colors">추가 완료</button>
                         </div>
-                    </div>
-                    <div class="flex justify-end gap-2">
-                        <button @click="isAddingCertification = false" class="px-3 py-1.5 text-xs text-slate-400 hover:text-white">취소</button>
-                        <button @click="addCertification" class="px-3 py-1.5 bg-yellow-600 hover:bg-yellow-500 text-white text-xs rounded-lg font-bold">추가 완료</button>
                     </div>
                 </div>
-            </div>
+            </section>
         </div>
     </div>
 </template>


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #65 

## 📝 작업 내용
### QA 사항
- [x] 프로필 하단 "프로필 수정" 제거
- [x] 고용주 평가 페이지 -> 리뷰페이지와 중복 아닌가 -> AI 평가로 대체
- [x] 회원 등급 산정 시 주의사항 잘 안보임 현상

### 그외 사항
- [x] 포트폴리오 업로드/다운로드 안됨 현상 개선
- [x] 계약관리 UI 개선

## ✅ Changes

### MyPageFreelancer.vue
- **Summary Profile**: 등급 배지, 주요 스킬 태그, 자기소개 카드 UI 개선
- **Project Status**: 지원 현황, 진행 중 프로젝트, 완료 프로젝트 통계 대시보드 구현
- **Quick Links**: 프로필 수정, 포트폴리오 관리 등 주요 액션 바로가기 배치

### ResumeManagementPage.vue
- **Interactive Forms**: 학력, 경력, 자격증 추가 시 모달/확장형 폼 적용으로 입력 편의성 증대
- **List View**: 등록된 이력 정보를 카드 형태로 시각화하여 가독성 개선

### ProjectManagementPage.vue
- **Tab Navigation**: 프로젝트 상태(제안, 진행, 종료)별 탭 분리 및 필터링 기능 강화
- **Visual Metrics**: 전문성 및 협업 능력 점수를 Progress Bar 형태로 시각화
- **AI Summary**: 고용주 평가 요약을 위한 AI 분석 섹션(Mock) UI 추가

### GradeCheckPage.vue
- 잘 안보이던 주의사항 분리 및 UI 개선

## 📸 스크린샷 (선택)
> (여기에 작업한 페이지들의 스크린샷을 첨부해주세요. 예: 대시보드, 이력서 관리 화면 등)
### 프로필 하단에 위치한 "프로필 수정" 제거
<img width="1155" height="376" alt="image" src="https://github.com/user-attachments/assets/8935f43d-6943-4a9a-b648-5e030af9ee66" />

### 고용주 평가 분석 페이지
<img width="1164" height="716" alt="image" src="https://github.com/user-attachments/assets/aa4d7540-391a-493a-8415-17152606baca" />

### 회원등급 산정과 주의사항 분리
<img width="492" height="611" alt="image" src="https://github.com/user-attachments/assets/6adf43d9-20fc-4d49-b8c4-0ce348308d77" />

## ⚠️ Notes (Optional)
- 이번 PR은 프론트엔드 UI/UX 개편에 집중되어 있으며, 실제 데이터 연동은 Mock API를 사용
- 백엔드 API 연동 시 `src/api/MyPage` 디렉토리 내의 함수들을 실제 엔드포인트로 교체 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 포트폴리오 파일 업로드·다운로드 기능 추가
  * 평가 페이지에 AI 분석/요약 및 상위 백분위수 표시 추가

* **Improvements**
  * 급여 입력을 월급 문자열에서 시급 숫자 입력으로 변경 및 표시 포맷 수정
  * 계정 관리·신원 인증 흐름 및 이력서/프로필 UI/UX 개선
  * 등급 산정 페이지 및 평가 목록 레이아웃·지표 개선

* **Other**
  * 평가 거절 피드백에 태그 필드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->