### PR TITLE
Hfp 109 feat(review): 리뷰 페이지 API 연동 및 계약 데이터 연계

### DIFF
--- a/freebridgefe/src/api/MyPage/employerFreelancerApi.ts
+++ b/freebridgefe/src/api/MyPage/employerFreelancerApi.ts
@@ -1,0 +1,54 @@
+import apiClient from '@/api/axiosInstance';
+
+interface ApiResponse<T> {
+    success: boolean;
+    message?: string;
+    data: T;
+}
+
+export interface EmployerFreelancerSearchItem {
+    freelancerId: number;
+    userId: number;
+    name: string;
+    job: string | null;
+    careerYears: number | null;
+    wage: number | null;
+    introduction: string | null;
+    avatarUrl: string | null;
+    skills: string[];
+    grade: string | null;
+}
+
+export interface EmployerFreelancerSearchResponse {
+    items: EmployerFreelancerSearchItem[];
+    page: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+}
+
+export interface EmployerFreelancerSearchParams {
+    page?: number;
+    size?: number;
+    keyword?: string;
+}
+
+export const getEmployerFreelancers = async (
+    params: EmployerFreelancerSearchParams = {}
+): Promise<EmployerFreelancerSearchResponse> => {
+    const response = await apiClient.get<ApiResponse<EmployerFreelancerSearchResponse>>(
+        '/api/employer/freelancers',
+        {
+            params: {
+                page: params.page ?? 0,
+                size: params.size ?? 20,
+                keyword: params.keyword?.trim() || undefined
+            }
+        }
+    );
+
+    return {
+        ...response.data.data,
+        items: response.data.data.items ?? []
+    };
+};

--- a/freebridgefe/src/api/contractApi.ts
+++ b/freebridgefe/src/api/contractApi.ts
@@ -1,0 +1,55 @@
+import apiClient from '@/api/axiosInstance';
+
+interface ApiResponse<T> {
+  success: boolean;
+  message?: string;
+  data: T;
+}
+
+export interface ContractSummaryDto {
+  id: number;
+  contractId: number;
+  projectName: string;
+  freelancerId: number;
+  employerId: number;
+  startDate: string;
+  endDate: string;
+  status: string;
+  budget: number;
+  employerSigned: boolean;
+  freelancerSigned: boolean;
+  freelancerName?: string | null;
+  employerName?: string | null;
+}
+
+export interface ContractListResponseDto {
+  items: ContractSummaryDto[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    totalPages: number;
+  };
+}
+
+export interface ListContractsParams {
+  status?: string[];
+  search?: string;
+  page?: number;
+  limit?: number;
+}
+
+export const listContracts = async (
+  params: ListContractsParams = {},
+): Promise<ContractListResponseDto> => {
+  const response = await apiClient.get<ApiResponse<ContractListResponseDto>>('/api/v1/contracts', {
+    params: {
+      status: params.status,
+      search: params.search,
+      page: params.page ?? 1,
+      limit: params.limit ?? 100,
+    },
+  });
+
+  return response.data.data;
+};

--- a/freebridgefe/src/api/proposalApi.ts
+++ b/freebridgefe/src/api/proposalApi.ts
@@ -1,0 +1,89 @@
+import apiClient from '@/api/axiosInstance';
+
+interface ApiResponse<T> {
+    success: boolean;
+    message?: string;
+    data: T;
+}
+
+export interface ProposalCreatePayload {
+    jobPostingId: number;
+    freelancerId: number;
+    message: string;
+}
+
+export interface ProposalCreateResult {
+    proposalId: number;
+}
+
+export interface ProposalResponseDto {
+    proposalId: number;
+    jobPostingId: number | null;
+    freelancerId: number;
+    employerId: number;
+    message: string;
+    status: 'PENDING' | 'ACCEPTED' | 'REJECTED';
+    createdAt: string;
+}
+
+export interface PagedResponseDto<T> {
+    content: T[];
+    page: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+}
+
+export const createEmployerProposal = async (
+    payload: ProposalCreatePayload
+): Promise<ProposalCreateResult> => {
+    const response = await apiClient.post<ApiResponse<ProposalCreateResult>>(
+        '/api/employer/proposals',
+        payload
+    );
+    return response.data.data;
+};
+
+export const getEmployerProposals = async (
+    page = 0,
+    size = 100
+): Promise<PagedResponseDto<ProposalResponseDto>> => {
+    const response = await apiClient.get<ApiResponse<PagedResponseDto<ProposalResponseDto>>>(
+        '/api/employer/proposals',
+        {
+            params: { page, size }
+        }
+    );
+    return response.data.data;
+};
+
+export const getFreelancerProposals = async (
+    page = 0,
+    size = 100
+): Promise<PagedResponseDto<ProposalResponseDto>> => {
+    const response = await apiClient.get<ApiResponse<PagedResponseDto<ProposalResponseDto>>>(
+        '/api/freelancer/proposal',
+        {
+            params: { page, size }
+        }
+    );
+    return response.data.data;
+};
+
+export const acceptFreelancerProposal = async (
+    proposalId: number
+): Promise<{ projectId: number }> => {
+    const response = await apiClient.patch<ApiResponse<{ projectId: number }>>(
+        `/api/freelancer/agree/${proposalId}`
+    );
+    return response.data.data;
+};
+
+export const rejectFreelancerProposal = async (
+    proposalId: number
+): Promise<{ proposalId: number }> => {
+    const response = await apiClient.patch<ApiResponse<{ proposalId: number }>>(
+        `/api/freelancer/deny/${proposalId}`
+    );
+    return response.data.data;
+};

--- a/freebridgefe/src/api/reviewApi.ts
+++ b/freebridgefe/src/api/reviewApi.ts
@@ -1,0 +1,228 @@
+import apiClient from '@/api/axiosInstance';
+
+interface ApiResponse<T> {
+  success: boolean;
+  message?: string;
+  data: T;
+}
+
+export interface PagedResponseDto<T> {
+  content: T[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+export interface EmployerReviewResponseDto {
+  id: number;
+  projectId: number;
+  employerId: number;
+  freelancerId: number;
+  language: number;
+  framework: number;
+  debugging: number;
+  communication: number;
+  schedule: number;
+  dispute: number;
+  description: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface FreelancerReviewResponseDto {
+  id: number;
+  projectId: number;
+  freelancerId: number;
+  employerId: number;
+  atmosphere: number;
+  requirementDetail: number;
+  schedule: number;
+  description: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface EmployerReviewCreatePayload {
+  freelancerId: number;
+  language: number;
+  framework: number;
+  debugging: number;
+  communication: number;
+  schedule: number;
+  dispute: number;
+  description: string;
+}
+
+export interface EmployerReviewUpdatePayload {
+  language: number;
+  framework: number;
+  debugging: number;
+  communication: number;
+  schedule: number;
+  dispute: number;
+  description: string;
+}
+
+export interface FreelancerReviewCreatePayload {
+  employerId: number;
+  atmosphere: number;
+  requirementDetail: number;
+  schedule: number;
+  description: string;
+}
+
+export interface FreelancerReviewUpdatePayload {
+  atmosphere: number;
+  requirementDetail: number;
+  schedule: number;
+  description: string;
+}
+
+export interface EmployerProjectReviewDto {
+  projectId: number;
+  jobPostingId: number;
+  freelancerId: number;
+  projectName: string;
+  headcount?: number | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  status: string;
+}
+
+export interface FreelancerMypageProjectDto {
+  projectId: number;
+  title: string;
+  employerName: string | null;
+  applyStatus: string | null;
+  appliedAt: number | null;
+}
+
+export const getEmployerReceivedReviews = async (
+  page = 0,
+  size = 100,
+): Promise<PagedResponseDto<FreelancerReviewResponseDto>> => {
+  const response = await apiClient.get<ApiResponse<PagedResponseDto<FreelancerReviewResponseDto>>>(
+    '/api/employer/reviews',
+    {
+      params: { page, size },
+    },
+  );
+
+  return response.data.data;
+};
+
+export const getEmployerWrittenReviews = async (
+  page = 0,
+  size = 100,
+): Promise<PagedResponseDto<EmployerReviewResponseDto>> => {
+  const response = await apiClient.get<ApiResponse<PagedResponseDto<EmployerReviewResponseDto>>>(
+    '/api/employer/reviews/written',
+    {
+      params: { page, size },
+    },
+  );
+
+  return response.data.data;
+};
+
+export const createEmployerReview = async (
+  projectId: number,
+  payload: EmployerReviewCreatePayload,
+): Promise<number> => {
+  const response = await apiClient.post<ApiResponse<number>>(
+    `/api/employer/projects/${projectId}/reviews`,
+    payload,
+  );
+
+  return response.data.data;
+};
+
+export const updateEmployerReview = async (
+  reviewId: number,
+  payload: EmployerReviewUpdatePayload,
+): Promise<void> => {
+  await apiClient.put<ApiResponse<null>>(`/api/employer/reviews/${reviewId}`, payload);
+};
+
+export const deleteEmployerReview = async (reviewId: number): Promise<void> => {
+  await apiClient.delete<ApiResponse<null>>(`/api/employer/reviews/${reviewId}`);
+};
+
+export const getFreelancerReceivedReviews = async (
+  page = 0,
+  size = 100,
+): Promise<PagedResponseDto<EmployerReviewResponseDto>> => {
+  const response = await apiClient.get<ApiResponse<PagedResponseDto<EmployerReviewResponseDto>>>(
+    '/api/freelancer/reviews',
+    {
+      params: { page, size },
+    },
+  );
+
+  return response.data.data;
+};
+
+export const getFreelancerWrittenReviews = async (
+  page = 0,
+  size = 100,
+): Promise<PagedResponseDto<FreelancerReviewResponseDto>> => {
+  const response = await apiClient.get<ApiResponse<PagedResponseDto<FreelancerReviewResponseDto>>>(
+    '/api/freelancer/reviews/written',
+    {
+      params: { page, size },
+    },
+  );
+
+  return response.data.data;
+};
+
+export const createFreelancerReview = async (
+  projectId: number,
+  payload: FreelancerReviewCreatePayload,
+): Promise<number> => {
+  const response = await apiClient.post<ApiResponse<number>>(
+    `/api/freelancer/projects/${projectId}/reviews`,
+    payload,
+  );
+
+  return response.data.data;
+};
+
+export const updateFreelancerReview = async (
+  reviewId: number,
+  payload: FreelancerReviewUpdatePayload,
+): Promise<void> => {
+  await apiClient.put<ApiResponse<null>>(`/api/freelancer/reviews/${reviewId}`, payload);
+};
+
+export const deleteFreelancerReview = async (reviewId: number): Promise<void> => {
+  await apiClient.delete<ApiResponse<null>>(`/api/freelancer/reviews/${reviewId}`);
+};
+
+export const getEmployerReviewProjects = async (
+  page = 0,
+  size = 100,
+): Promise<PagedResponseDto<EmployerProjectReviewDto>> => {
+  const response = await apiClient.get<ApiResponse<PagedResponseDto<EmployerProjectReviewDto>>>(
+    '/api/employer/project',
+    {
+      params: { page, size },
+    },
+  );
+
+  return response.data.data;
+};
+
+export const getFreelancerMypageProjects = async (
+  status?: string,
+): Promise<FreelancerMypageProjectDto[]> => {
+  const response = await apiClient.get<ApiResponse<FreelancerMypageProjectDto[]>>(
+    '/api/freelancer/mypage/projects',
+    {
+      params: status ? { status } : undefined,
+    },
+  );
+
+  return response.data.data ?? [];
+};

--- a/freebridgefe/src/stores/freelancerStore.ts
+++ b/freebridgefe/src/stores/freelancerStore.ts
@@ -1,13 +1,54 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
 import { getFreelancerRecommendations } from "@/api/recommendationApi";
+import {
+  acceptFreelancerProposal,
+  createEmployerProposal,
+  getEmployerProposals,
+  getFreelancerProposals,
+  rejectFreelancerProposal,
+  type ProposalResponseDto,
+} from "@/api/proposalApi";
+import { getUserById } from "@/api/authApi";
 import type { User, Proposal } from "@/types";
+import { useAuthStore } from "@/stores/authStore";
 import { useChatStore } from "@/stores/chatStore";
+import { useJobStore } from "@/stores/jobStore";
+
+const toNumericId = (value: string | number, label: string): number => {
+  const raw = String(value);
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`${label} ID가 올바르지 않습니다.`);
+  }
+  return Number(raw);
+};
+
+const getProposalErrorMessage = (error: unknown): string => {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "response" in error &&
+    typeof (error as any).response?.data?.message === "string"
+  ) {
+    return (error as any).response.data.message;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "제안 정보를 처리하지 못했습니다.";
+};
 
 export const useFreelancerStore = defineStore("freelancer", () => {
+  const authStore = useAuthStore();
   const freelancers = ref<(User & { matchScore?: number })[]>([]);
   const recommendedFetchError = ref<string | null>(null);
   const isFetchingRecommended = ref(false);
+  const proposals = ref<Proposal[]>([]);
+  const isFetchingProposals = ref(false);
+  const proposalFetchError = ref<string | null>(null);
+  const userNameCache: Record<string, string> = {};
 
   async function fetchRecommendedFreelancers(jobId: number) {
     isFetchingRecommended.value = true;
@@ -35,40 +76,141 @@ export const useFreelancerStore = defineStore("freelancer", () => {
     }
   }
 
-  const proposals = ref<Proposal[]>([
-    {
-      id: "proposal-1",
-      employerId: "e1",
-      employerName: "스타트업 A",
-      freelancerId: "f1",
-      freelancerName: "김프론트",
-      jobId: "job1",
-      message:
-        "대시보드 고도화 프로젝트에 합류해주실 수 있을까요? 기술 인터뷰 없이 바로 협의 가능합니다.",
-      status: "PENDING",
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 20),
-    },
-    {
-      id: "proposal-2",
-      employerId: "e1",
-      employerName: "스타트업 A",
-      freelancerId: "f3",
-      freelancerName: "박풀스택",
-      jobId: "job2",
-      message:
-        "백엔드 안정화 작업 제안을 드립니다. 가능 일정 회신 부탁드립니다.",
-      status: "ACCEPTED",
-      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 48),
-    },
-  ]);
+  const getCurrentEmployerName = () =>
+    authStore.user?.companyName || authStore.user?.name || "고용주";
 
-  function addProposal(proposal: Omit<Proposal, "id" | "createdAt">) {
+  const getCurrentFreelancerName = () => authStore.user?.name || "프리랜서";
+
+  async function resolveUserNames(userIds: string[]): Promise<Record<string, string>> {
+    const uniqueIds = Array.from(new Set(userIds.filter(Boolean)));
+    const missingIds = uniqueIds.filter((id) => !userNameCache[id]);
+
+    await Promise.all(
+      missingIds.map(async (id) => {
+        try {
+          const user = await getUserById(Number(id));
+          userNameCache[id] = user?.name || "";
+        } catch {
+          userNameCache[id] = "";
+        }
+      }),
+    );
+
+    return uniqueIds.reduce<Record<string, string>>((acc, id) => {
+      if (userNameCache[id]) {
+        acc[id] = userNameCache[id];
+      }
+      return acc;
+    }, {});
+  }
+
+  function mapProposal(dto: ProposalResponseDto, names: Record<string, string>): Proposal {
+    const jobStore = useJobStore();
+    const jobId = dto.jobPostingId === null ? undefined : String(dto.jobPostingId);
+    const job = jobId ? jobStore.getJobById(jobId) : undefined;
+    const currentUserId = String(authStore.user?.id ?? "");
+
+    const employerName =
+      String(dto.employerId) === currentUserId && authStore.user?.role === "EMPLOYER"
+        ? getCurrentEmployerName()
+        : job?.employerName || names[String(dto.employerId)] || `고용주 #${dto.employerId}`;
+
+    const freelancerName =
+      String(dto.freelancerId) === currentUserId && authStore.user?.role === "FREELANCER"
+        ? getCurrentFreelancerName()
+        : names[String(dto.freelancerId)] || `프리랜서 #${dto.freelancerId}`;
+
+    return {
+      id: String(dto.proposalId),
+      employerId: String(dto.employerId),
+      employerName,
+      freelancerId: String(dto.freelancerId),
+      freelancerName,
+      jobId,
+      message: dto.message,
+      status: dto.status,
+      createdAt: new Date(dto.createdAt),
+    };
+  }
+
+  async function hydrateProposals(items: ProposalResponseDto[]): Promise<Proposal[]> {
+    const ids = items.flatMap((item) => [
+      String(item.employerId),
+      String(item.freelancerId),
+    ]);
+    const names = await resolveUserNames(ids);
+    return items.map((item) => mapProposal(item, names));
+  }
+
+  async function fetchEmployerProposalList(page = 0, size = 100) {
+    if (!authStore.user || authStore.user.role !== "EMPLOYER") {
+      proposals.value = [];
+      return;
+    }
+
+    isFetchingProposals.value = true;
+    proposalFetchError.value = null;
+
+    try {
+      const response = await getEmployerProposals(page, size);
+      proposals.value = await hydrateProposals(response.content ?? []);
+      return response;
+    } catch (error) {
+      proposals.value = [];
+      proposalFetchError.value = getProposalErrorMessage(error);
+      throw error;
+    } finally {
+      isFetchingProposals.value = false;
+    }
+  }
+
+  async function fetchFreelancerProposalList(page = 0, size = 100) {
+    if (!authStore.user || authStore.user.role !== "FREELANCER") {
+      proposals.value = [];
+      return;
+    }
+
+    isFetchingProposals.value = true;
+    proposalFetchError.value = null;
+
+    try {
+      const response = await getFreelancerProposals(page, size);
+      proposals.value = await hydrateProposals(response.content ?? []);
+      return response;
+    } catch (error) {
+      proposals.value = [];
+      proposalFetchError.value = getProposalErrorMessage(error);
+      throw error;
+    } finally {
+      isFetchingProposals.value = false;
+    }
+  }
+
+  async function addProposal(
+    proposal: Omit<Proposal, "id" | "createdAt">,
+  ): Promise<Proposal> {
+    if (!authStore.user || authStore.user.role !== "EMPLOYER") {
+      throw new Error("고용주만 제안을 보낼 수 있습니다.");
+    }
+
+    const result = await createEmployerProposal({
+      jobPostingId: toNumericId(proposal.jobId || "", "공고"),
+      freelancerId: toNumericId(proposal.freelancerId, "프리랜서"),
+      message: proposal.message,
+    });
+
     const newProposal: Proposal = {
       ...proposal,
-      id: `p${Date.now()}`,
+      id: String(result.proposalId),
       createdAt: new Date(),
     };
-    proposals.value = [newProposal, ...proposals.value];
+
+    proposals.value = [
+      newProposal,
+      ...proposals.value.filter((item) => item.id !== newProposal.id),
+    ];
+
+    return newProposal;
   }
 
   function getProposalsByFreelancer(freelancerId: string) {
@@ -77,19 +219,24 @@ export const useFreelancerStore = defineStore("freelancer", () => {
     );
   }
 
-  function updateProposalStatus(
+  async function updateProposalStatus(
     proposalId: string,
     status: Proposal["status"],
     rejectionReason?: string,
-  ): string | boolean | null {
+  ): Promise<string | boolean | null> {
     const index = proposals.value.findIndex(
       (p: Proposal) => p.id === proposalId,
     );
     if (index === -1) return null;
 
+    if (status === "ACCEPTED") {
+      await acceptFreelancerProposal(toNumericId(proposalId, "제안"));
+    } else if (status === "REJECTED") {
+      await rejectFreelancerProposal(toNumericId(proposalId, "제안"));
+    }
+
     const proposal = proposals.value[index];
 
-    // Update local state
     proposals.value[index] = {
       ...proposal,
       status,
@@ -130,7 +277,11 @@ export const useFreelancerStore = defineStore("freelancer", () => {
     recommendedFetchError,
     isFetchingRecommended,
     fetchRecommendedFreelancers,
+    isFetchingProposals,
+    proposalFetchError,
     proposals,
+    fetchEmployerProposals: fetchEmployerProposalList,
+    fetchFreelancerProposals: fetchFreelancerProposalList,
     addProposal,
     getProposalsByFreelancer,
     updateProposalStatus,

--- a/freebridgefe/src/stores/reviewStore.ts
+++ b/freebridgefe/src/stores/reviewStore.ts
@@ -1,9 +1,36 @@
 import { defineStore } from 'pinia';
-import { ref, watch } from 'vue';
+import { ref } from 'vue';
+import { getUserById } from '@/api/authApi';
+import { listContracts, type ContractSummaryDto } from '@/api/contractApi';
+import { getEmployerProjects as getEmployerMypageProjects } from '@/api/MyPage/projectApi';
+import {
+  createEmployerReview,
+  createFreelancerReview,
+  deleteEmployerReview,
+  deleteFreelancerReview,
+  getEmployerReceivedReviews,
+  getEmployerReviewProjects,
+  getEmployerWrittenReviews,
+  getFreelancerMypageProjects,
+  getFreelancerReceivedReviews,
+  getFreelancerWrittenReviews,
+  updateEmployerReview,
+  updateFreelancerReview,
+  type EmployerProjectReviewDto,
+  type EmployerReviewCreatePayload,
+  type EmployerReviewResponseDto,
+  type EmployerReviewUpdatePayload,
+  type FreelancerReviewCreatePayload,
+  type FreelancerReviewResponseDto,
+  type FreelancerReviewUpdatePayload,
+} from '@/api/reviewApi';
+import { useAuthStore } from '@/stores/authStore';
 
 export interface FreelancerToEmployerReview {
   id: string;
+  projectId?: string | number;
   freelancerId?: string | number;
+  employerId?: string | number;
   freelancerName: string;
   companyName: string;
   projectName: string;
@@ -17,6 +44,7 @@ export interface FreelancerToEmployerReview {
 
 export interface EmployerToFreelancerReview {
   id: string;
+  projectId?: string | number;
   employerId?: string | number;
   employerName: string;
   freelancerId?: string | number;
@@ -33,158 +61,686 @@ export interface EmployerToFreelancerReview {
   createdAt: string;
 }
 
-const STORAGE_KEY = 'review-store-v1';
+export interface ReviewWriteTarget {
+  key: string;
+  projectId: string;
+  counterpartyId: string;
+  projectName: string;
+  counterpartyName: string;
+}
 
-const defaultFreelancerToEmployerReviews: FreelancerToEmployerReview[] = [
-  {
-    id: 'fe-1',
-    freelancerId: 'f1',
-    freelancerName: '김프론트',
-    companyName: '프리브릿지',
-    projectName: '대시보드 고도화',
-    rating: 4.6,
-    atmosphere: 5,
-    requirementDetail: 4,
-    schedule: 4,
-    comment: '요구사항이 명확했고 커뮤니케이션이 원활했습니다. 일정 조율도 합리적으로 진행되었습니다.',
-    createdAt: '2024-09-20',
+const EMPTY_CONTRACT_LIST = {
+  items: [] as ContractSummaryDto[],
+  pagination: {
+    page: 1,
+    limit: 100,
+    total: 0,
+    totalPages: 0,
   },
-];
+};
 
-const defaultEmployerToFreelancerReviews: EmployerToFreelancerReview[] = [
-  {
-    id: 'ef-1',
-    employerId: 'e1',
-    employerName: '프리브릿지',
-    freelancerId: 'f1',
-    freelancerName: '김프론트',
-    projectName: '모바일 앱 리팩토링',
-    rating: 4.7,
-    language: 5,
-    framework: 5,
-    debugging: 4,
-    communication: 5,
-    schedule: 4,
-    dispute: 5,
-    comment: '업무 결과물의 퀄리티가 높았고 커뮤니케이션도 원활했습니다.',
-    createdAt: '2024-10-03',
-  },
-];
+const average = (scores: number[]) => {
+  const validScores = scores.filter((score) => Number.isFinite(score));
+  if (validScores.length === 0) {
+    return 0;
+  }
+
+  const sum = validScores.reduce((acc, value) => acc + value, 0);
+  return Number((sum / validScores.length).toFixed(1));
+};
+
+const toStringId = (value: string | number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return String(value);
+};
+
+const toNumericId = (value: string | number, label: string) => {
+  const raw = String(value);
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`${label} ID가 올바르지 않습니다.`);
+  }
+
+  return Number(raw);
+};
+
+const getProjectFallbackLabel = (projectId: string | number | null | undefined) =>
+  projectId === null || projectId === undefined || projectId === ''
+    ? '프로젝트 정보 없음'
+    : `프로젝트 #${projectId}`;
+
+const getReviewErrorMessage = (error: unknown, fallback: string) => {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    typeof (error as any).response?.data?.message === 'string'
+  ) {
+    return (error as any).response.data.message;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+};
+
+const buildLookup = <T>(
+  items: T[],
+  getKey: (item: T) => string | number | null | undefined,
+  getValue: (item: T) => string | null | undefined,
+) =>
+  items.reduce<Record<string, string>>((acc, item) => {
+    const key = getKey(item);
+    const value = getValue(item);
+
+    if (key !== null && key !== undefined && value) {
+      acc[String(key)] = value;
+    }
+
+    return acc;
+  }, {});
+
+const resolveProjectName = (
+  projectId: string | number | null | undefined,
+  ...maps: Array<Record<string, string>>
+) => {
+  const key = toStringId(projectId);
+
+  for (const map of maps) {
+    if (key && map[key]) {
+      return map[key];
+    }
+  }
+
+  return getProjectFallbackLabel(projectId);
+};
 
 export const useReviewStore = defineStore('review', () => {
-  const freelancerToEmployerReviews = ref<FreelancerToEmployerReview[]>([...defaultFreelancerToEmployerReviews]);
-  const employerToFreelancerReviews = ref<EmployerToFreelancerReview[]>([...defaultEmployerToFreelancerReviews]);
+  const authStore = useAuthStore();
 
-  const loadFromStorage = () => {
-    if (typeof window === 'undefined') return;
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return;
+  const freelancerToEmployerReviews = ref<FreelancerToEmployerReview[]>([]);
+  const employerToFreelancerReviews = ref<EmployerToFreelancerReview[]>([]);
+  const employerReviewTargets = ref<ReviewWriteTarget[]>([]);
+  const freelancerReviewTargets = ref<ReviewWriteTarget[]>([]);
+
+  const isFetchingReviews = ref(false);
+  const reviewFetchError = ref<string | null>(null);
+  const isFetchingReviewTargets = ref(false);
+  const reviewTargetFetchError = ref<string | null>(null);
+  const isSubmittingReview = ref(false);
+
+  const userDisplayNameCache: Record<string, string> = {};
+
+  const getCurrentEmployerName = () =>
+    authStore.user?.companyName || authStore.user?.name || '고용주';
+
+  const getCurrentFreelancerName = () => authStore.user?.name || '프리랜서';
+
+  const getUserDisplayName = (user: any) => user?.companyName || user?.name || '';
+
+  async function resolveUserDisplayNames(
+    userIds: Array<string | number | null | undefined>,
+  ): Promise<Record<string, string>> {
+    const uniqueIds = Array.from(
+      new Set(
+        userIds
+          .map((value) => toStringId(value))
+          .filter((value) => value.length > 0),
+      ),
+    );
+
+    const missingIds = uniqueIds.filter((id) => !userDisplayNameCache[id]);
+
+    await Promise.all(
+      missingIds.map(async (id) => {
+        try {
+          const user = await getUserById(Number(id));
+          userDisplayNameCache[id] = getUserDisplayName(user) || '';
+        } catch {
+          userDisplayNameCache[id] = '';
+        }
+      }),
+    );
+
+    return uniqueIds.reduce<Record<string, string>>((acc, id) => {
+      if (userDisplayNameCache[id]) {
+        acc[id] = userDisplayNameCache[id];
+      }
+      return acc;
+    }, {});
+  }
+
+  async function safeListContracts(status?: string[]) {
+    try {
+      return await listContracts({ status, page: 1, limit: 100 });
+    } catch {
+      return EMPTY_CONTRACT_LIST;
+    }
+  }
+
+  async function safeEmployerMypageProjects() {
+    try {
+      return await getEmployerMypageProjects();
+    } catch {
+      return [];
+    }
+  }
+
+  async function safeFreelancerMypageProjects() {
+    try {
+      return await getFreelancerMypageProjects();
+    } catch {
+      return [];
+    }
+  }
+
+  async function safeEmployerProjectSearches() {
+    try {
+      return await getEmployerReviewProjects(0, 100);
+    } catch {
+      return {
+        content: [] as EmployerProjectReviewDto[],
+        page: 0,
+        size: 100,
+        totalElements: 0,
+        totalPages: 0,
+      };
+    }
+  }
+
+  function mapEmployerReview(
+    review: EmployerReviewResponseDto,
+    employerNames: Record<string, string>,
+    freelancerNames: Record<string, string>,
+    projectNames: Record<string, string>,
+  ): EmployerToFreelancerReview {
+    return {
+      id: String(review.id),
+      projectId: String(review.projectId),
+      employerId: String(review.employerId),
+      employerName:
+        authStore.user?.role === 'EMPLOYER' &&
+        String(review.employerId) === toStringId(authStore.user?.id)
+          ? getCurrentEmployerName()
+          : employerNames[String(review.employerId)] || `기업 #${review.employerId}`,
+      freelancerId: String(review.freelancerId),
+      freelancerName:
+        freelancerNames[String(review.freelancerId)] || `프리랜서 #${review.freelancerId}`,
+      projectName: resolveProjectName(review.projectId, projectNames),
+      language: review.language ?? 0,
+      framework: review.framework ?? 0,
+      debugging: review.debugging ?? 0,
+      communication: review.communication ?? 0,
+      schedule: review.schedule ?? 0,
+      dispute: review.dispute ?? 0,
+      rating: average([
+        review.language ?? 0,
+        review.framework ?? 0,
+        review.debugging ?? 0,
+        review.communication ?? 0,
+        review.schedule ?? 0,
+        review.dispute ?? 0,
+      ]),
+      comment: review.description ?? '',
+      createdAt: review.createdAt,
+    };
+  }
+
+  function mapFreelancerReview(
+    review: FreelancerReviewResponseDto,
+    freelancerNames: Record<string, string>,
+    employerNames: Record<string, string>,
+    projectNames: Record<string, string>,
+  ): FreelancerToEmployerReview {
+    return {
+      id: String(review.id),
+      projectId: String(review.projectId),
+      freelancerId: String(review.freelancerId),
+      employerId: String(review.employerId),
+      freelancerName:
+        String(review.freelancerId) === toStringId(authStore.user?.id)
+          ? getCurrentFreelancerName()
+          : freelancerNames[String(review.freelancerId)] || `프리랜서 #${review.freelancerId}`,
+      companyName:
+        String(review.employerId) === toStringId(authStore.user?.id)
+          ? getCurrentEmployerName()
+          : employerNames[String(review.employerId)] || `기업 #${review.employerId}`,
+      projectName: resolveProjectName(review.projectId, projectNames),
+      atmosphere: review.atmosphere ?? 0,
+      requirementDetail: review.requirementDetail ?? 0,
+      schedule: review.schedule ?? 0,
+      rating: average([
+        review.atmosphere ?? 0,
+        review.requirementDetail ?? 0,
+        review.schedule ?? 0,
+      ]),
+      comment: review.description ?? '',
+      createdAt: review.createdAt,
+    };
+  }
+
+  async function fetchEmployerReviews(page = 0, size = 100) {
+    if (!authStore.user || authStore.user.role !== 'EMPLOYER') {
+      employerToFreelancerReviews.value = [];
+      freelancerToEmployerReviews.value = [];
+      return;
+    }
+
+    isFetchingReviews.value = true;
+    reviewFetchError.value = null;
 
     try {
-      const parsed = JSON.parse(raw) as {
-        freelancerToEmployerReviews?: FreelancerToEmployerReview[];
-        employerToFreelancerReviews?: EmployerToFreelancerReview[];
+      const [writtenResponse, receivedResponse, actualProjects, jobPostingProjects, contracts] =
+        await Promise.all([
+          getEmployerWrittenReviews(page, size),
+          getEmployerReceivedReviews(page, size),
+          safeEmployerProjectSearches(),
+          safeEmployerMypageProjects(),
+          safeListContracts(['IN_PROGRESS', 'COMPLETED']),
+        ]);
+
+      const freelancerNames = await resolveUserDisplayNames([
+        ...writtenResponse.content.map((review) => review.freelancerId),
+        ...receivedResponse.content.map((review) => review.freelancerId),
+      ]);
+
+      const actualProjectNames = buildLookup(
+        actualProjects.content ?? [],
+        (item) => item.projectId,
+        (item) => item.projectName,
+      );
+      const jobPostingProjectNames = buildLookup(
+        jobPostingProjects,
+        (item) => item.projectId,
+        (item) => item.title,
+      );
+      const contractProjectNames = buildLookup(
+        contracts.items ?? [],
+        (item) => item.id,
+        (item) => item.projectName,
+      );
+
+      employerToFreelancerReviews.value = (writtenResponse.content ?? []).map((review) =>
+        mapEmployerReview(
+          review,
+          {
+            [toStringId(authStore.user?.id)]: getCurrentEmployerName(),
+          },
+          freelancerNames,
+          {
+          ...contractProjectNames,
+          ...actualProjectNames,
+          },
+        ),
+      );
+
+      freelancerToEmployerReviews.value = (receivedResponse.content ?? []).map((review) =>
+        mapFreelancerReview(
+          review,
+          freelancerNames,
+          {
+            [toStringId(authStore.user?.id)]: getCurrentEmployerName(),
+          },
+          {
+            ...jobPostingProjectNames,
+            ...contractProjectNames,
+            ...actualProjectNames,
+          },
+        ),
+      );
+
+      return {
+        written: employerToFreelancerReviews.value,
+        received: freelancerToEmployerReviews.value,
+      };
+    } catch (error) {
+      employerToFreelancerReviews.value = [];
+      freelancerToEmployerReviews.value = [];
+      reviewFetchError.value = getReviewErrorMessage(error, '후기 목록을 불러오지 못했습니다.');
+      throw error;
+    } finally {
+      isFetchingReviews.value = false;
+    }
+  }
+
+  async function fetchFreelancerReviews(page = 0, size = 100) {
+    if (!authStore.user || authStore.user.role !== 'FREELANCER') {
+      employerToFreelancerReviews.value = [];
+      freelancerToEmployerReviews.value = [];
+      return;
+    }
+
+    isFetchingReviews.value = true;
+    reviewFetchError.value = null;
+
+    try {
+      const [writtenResponse, receivedResponse, mypageProjects, contracts] = await Promise.all([
+        getFreelancerWrittenReviews(page, size),
+        getFreelancerReceivedReviews(page, size),
+        safeFreelancerMypageProjects(),
+        safeListContracts(['IN_PROGRESS', 'COMPLETED']),
+      ]);
+
+      const employerNames = await resolveUserDisplayNames([
+        ...writtenResponse.content.map((review) => review.employerId),
+        ...receivedResponse.content.map((review) => review.employerId),
+      ]);
+
+      const contractProjectNames = buildLookup(
+        contracts.items ?? [],
+        (item) => item.id,
+        (item) => item.projectName,
+      );
+      const mypageProjectNames = buildLookup(
+        mypageProjects,
+        (item) => item.projectId,
+        (item) => item.title,
+      );
+
+      freelancerToEmployerReviews.value = (writtenResponse.content ?? []).map((review) =>
+        mapFreelancerReview(
+          review,
+          {
+            [toStringId(authStore.user?.id)]: getCurrentFreelancerName(),
+          },
+          employerNames,
+          {
+            ...contractProjectNames,
+            ...mypageProjectNames,
+          },
+        ),
+      );
+
+      employerToFreelancerReviews.value = (receivedResponse.content ?? []).map((review) =>
+        mapEmployerReview(
+          review,
+          employerNames,
+          {
+          [toStringId(authStore.user?.id)]: getCurrentFreelancerName(),
+          },
+          {
+          ...contractProjectNames,
+          ...mypageProjectNames,
+          },
+        ),
+      );
+
+      return {
+        written: freelancerToEmployerReviews.value,
+        received: employerToFreelancerReviews.value,
+      };
+    } catch (error) {
+      employerToFreelancerReviews.value = [];
+      freelancerToEmployerReviews.value = [];
+      reviewFetchError.value = getReviewErrorMessage(error, '후기 목록을 불러오지 못했습니다.');
+      throw error;
+    } finally {
+      isFetchingReviews.value = false;
+    }
+  }
+
+  async function fetchEmployerReviewTargets() {
+    if (!authStore.user || authStore.user.role !== 'EMPLOYER') {
+      employerReviewTargets.value = [];
+      return [];
+    }
+
+    isFetchingReviewTargets.value = true;
+    reviewTargetFetchError.value = null;
+
+    try {
+      const [projectsResponse, writtenResponse] = await Promise.all([
+        getEmployerReviewProjects(0, 100),
+        getEmployerWrittenReviews(0, 100),
+      ]);
+
+      const reviewableProjects = (projectsResponse.content ?? []).filter(
+        (item) => item.status === 'IN_PROGRESS',
+      );
+      const freelancerNames = await resolveUserDisplayNames(
+        reviewableProjects.map((item) => item.freelancerId),
+      );
+      const writtenKeys = new Set(
+        (writtenResponse.content ?? []).map(
+          (item) => `${String(item.projectId)}:${String(item.freelancerId)}`,
+        ),
+      );
+
+      employerReviewTargets.value = reviewableProjects
+        .filter((item) => !writtenKeys.has(`${String(item.projectId)}:${String(item.freelancerId)}`))
+        .map((item) => ({
+          key: `${String(item.projectId)}:${String(item.freelancerId)}`,
+          projectId: String(item.projectId),
+          counterpartyId: String(item.freelancerId),
+          projectName: item.projectName || getProjectFallbackLabel(item.projectId),
+          counterpartyName:
+            freelancerNames[String(item.freelancerId)] || `프리랜서 #${item.freelancerId}`,
+        }));
+
+      return employerReviewTargets.value;
+    } catch (error) {
+      employerReviewTargets.value = [];
+      reviewTargetFetchError.value = getReviewErrorMessage(
+        error,
+        '후기 작성 대상을 불러오지 못했습니다.',
+      );
+      throw error;
+    } finally {
+      isFetchingReviewTargets.value = false;
+    }
+  }
+
+  async function fetchFreelancerReviewTargets() {
+    if (!authStore.user || authStore.user.role !== 'FREELANCER') {
+      freelancerReviewTargets.value = [];
+      return [];
+    }
+
+    isFetchingReviewTargets.value = true;
+    reviewTargetFetchError.value = null;
+
+    try {
+      const [contracts, writtenResponse] = await Promise.all([
+        listContracts({ status: ['IN_PROGRESS', 'COMPLETED'], page: 1, limit: 100 }),
+        getFreelancerWrittenReviews(0, 100),
+      ]);
+
+      const writtenKeys = new Set(
+        (writtenResponse.content ?? []).map(
+          (item) => `${String(item.projectId)}:${String(item.employerId)}`,
+        ),
+      );
+
+      freelancerReviewTargets.value = (contracts.items ?? [])
+        .filter((item) => ['IN_PROGRESS', 'COMPLETED'].includes(item.status))
+        .filter((item) => !writtenKeys.has(`${String(item.id)}:${String(item.employerId)}`))
+        .map((item) => ({
+          key: `${String(item.id)}:${String(item.employerId)}`,
+          projectId: String(item.id),
+          counterpartyId: String(item.employerId),
+          projectName: item.projectName || getProjectFallbackLabel(item.id),
+          counterpartyName: item.employerName || `기업 #${item.employerId}`,
+        }));
+
+      return freelancerReviewTargets.value;
+    } catch (error) {
+      freelancerReviewTargets.value = [];
+      reviewTargetFetchError.value = getReviewErrorMessage(
+        error,
+        '후기 작성 대상을 불러오지 못했습니다.',
+      );
+      throw error;
+    } finally {
+      isFetchingReviewTargets.value = false;
+    }
+  }
+
+  async function addEmployerToFreelancerReview(
+    payload: Omit<
+      EmployerToFreelancerReview,
+      'id' | 'createdAt' | 'rating' | 'employerName'
+    > & { projectId: string | number; freelancerId: string | number },
+  ) {
+    isSubmittingReview.value = true;
+
+    try {
+      const request: EmployerReviewCreatePayload = {
+        freelancerId: toNumericId(payload.freelancerId, '프리랜서'),
+        language: payload.language,
+        framework: payload.framework,
+        debugging: payload.debugging,
+        communication: payload.communication,
+        schedule: payload.schedule,
+        dispute: payload.dispute,
+        description: payload.comment.trim(),
       };
 
-      if (Array.isArray(parsed.freelancerToEmployerReviews)) {
-        freelancerToEmployerReviews.value = parsed.freelancerToEmployerReviews;
-      }
-      if (Array.isArray(parsed.employerToFreelancerReviews)) {
-        employerToFreelancerReviews.value = parsed.employerToFreelancerReviews;
-      }
-    } catch (error) {
-      console.error('Failed to parse review store from localStorage', error);
+      await createEmployerReview(toNumericId(payload.projectId, '프로젝트'), request);
+      await Promise.all([fetchEmployerReviews(), fetchEmployerReviewTargets()]);
+    } finally {
+      isSubmittingReview.value = false;
     }
-  };
+  }
 
-  const persist = () => {
-    if (typeof window === 'undefined') return;
-    localStorage.setItem(
-      STORAGE_KEY,
-      JSON.stringify({
-        freelancerToEmployerReviews: freelancerToEmployerReviews.value,
-        employerToFreelancerReviews: employerToFreelancerReviews.value,
-      })
-    );
-  };
-
-  const average = (scores: number[]) => Number((scores.reduce((acc, v) => acc + v, 0) / scores.length).toFixed(1));
-
-  function addFreelancerToEmployerReview(
-    payload: Omit<FreelancerToEmployerReview, 'id' | 'createdAt' | 'rating'>
+  async function addFreelancerToEmployerReview(
+    payload: Omit<
+      FreelancerToEmployerReview,
+      'id' | 'createdAt' | 'rating' | 'freelancerName'
+    > & { projectId: string | number; employerId: string | number },
   ) {
-    const review: FreelancerToEmployerReview = {
-      ...payload,
-      id: `fe-${Date.now()}`,
-      createdAt: new Date().toISOString(),
-      rating: average([payload.atmosphere, payload.requirementDetail, payload.schedule]),
-    };
-    freelancerToEmployerReviews.value = [review, ...freelancerToEmployerReviews.value];
+    isSubmittingReview.value = true;
+
+    try {
+      const request: FreelancerReviewCreatePayload = {
+        employerId: toNumericId(payload.employerId, '기업'),
+        atmosphere: payload.atmosphere,
+        requirementDetail: payload.requirementDetail,
+        schedule: payload.schedule,
+        description: payload.comment.trim(),
+      };
+
+      await createFreelancerReview(toNumericId(payload.projectId, '프로젝트'), request);
+      await Promise.all([fetchFreelancerReviews(), fetchFreelancerReviewTargets()]);
+    } finally {
+      isSubmittingReview.value = false;
+    }
   }
 
-  function addEmployerToFreelancerReview(
-    payload: Omit<EmployerToFreelancerReview, 'id' | 'createdAt' | 'rating'>
+  async function updateFreelancerToEmployerReview(
+    id: string,
+    updates: Partial<FreelancerToEmployerReview>,
   ) {
-    const review: EmployerToFreelancerReview = {
-      ...payload,
-      id: `ef-${Date.now()}`,
-      createdAt: new Date().toISOString(),
-      rating: average([
-        payload.language,
-        payload.framework,
-        payload.debugging,
-        payload.communication,
-        payload.schedule,
-        payload.dispute,
-      ]),
-    };
-    employerToFreelancerReviews.value = [review, ...employerToFreelancerReviews.value];
+    const currentReview = freelancerToEmployerReviews.value.find((review) => review.id === id);
+    if (!currentReview) {
+      return;
+    }
+
+    isSubmittingReview.value = true;
+
+    try {
+      const request: FreelancerReviewUpdatePayload = {
+        atmosphere: updates.atmosphere ?? currentReview.atmosphere,
+        requirementDetail: updates.requirementDetail ?? currentReview.requirementDetail,
+        schedule: updates.schedule ?? currentReview.schedule,
+        description: (updates.comment ?? currentReview.comment).trim(),
+      };
+
+      await updateFreelancerReview(toNumericId(id, '후기'), request);
+
+      if (authStore.user?.role === 'FREELANCER') {
+        await fetchFreelancerReviews();
+      } else {
+        await fetchEmployerReviews();
+      }
+    } finally {
+      isSubmittingReview.value = false;
+    }
   }
 
-  function updateFreelancerToEmployerReview(id: string, updates: Partial<FreelancerToEmployerReview>) {
-    const index = freelancerToEmployerReviews.value.findIndex((review) => review.id === id);
-    if (index === -1) return;
-    const next = { ...freelancerToEmployerReviews.value[index], ...updates };
-    next.rating = average([next.atmosphere, next.requirementDetail, next.schedule]);
-    freelancerToEmployerReviews.value[index] = next;
+  async function updateEmployerToFreelancerReview(
+    id: string,
+    updates: Partial<EmployerToFreelancerReview>,
+  ) {
+    const currentReview = employerToFreelancerReviews.value.find((review) => review.id === id);
+    if (!currentReview) {
+      return;
+    }
+
+    isSubmittingReview.value = true;
+
+    try {
+      const request: EmployerReviewUpdatePayload = {
+        language: updates.language ?? currentReview.language,
+        framework: updates.framework ?? currentReview.framework,
+        debugging: updates.debugging ?? currentReview.debugging,
+        communication: updates.communication ?? currentReview.communication,
+        schedule: updates.schedule ?? currentReview.schedule,
+        dispute: updates.dispute ?? currentReview.dispute,
+        description: (updates.comment ?? currentReview.comment).trim(),
+      };
+
+      await updateEmployerReview(toNumericId(id, '후기'), request);
+
+      if (authStore.user?.role === 'EMPLOYER') {
+        await fetchEmployerReviews();
+      } else {
+        await fetchFreelancerReviews();
+      }
+    } finally {
+      isSubmittingReview.value = false;
+    }
   }
 
-  function updateEmployerToFreelancerReview(id: string, updates: Partial<EmployerToFreelancerReview>) {
-    const index = employerToFreelancerReviews.value.findIndex((review) => review.id === id);
-    if (index === -1) return;
-    const next = { ...employerToFreelancerReviews.value[index], ...updates };
-    next.rating = average([
-      next.language,
-      next.framework,
-      next.debugging,
-      next.communication,
-      next.schedule,
-      next.dispute,
-    ]);
-    employerToFreelancerReviews.value[index] = next;
+  async function deleteFreelancerToEmployerReview(id: string) {
+    isSubmittingReview.value = true;
+
+    try {
+      await deleteFreelancerReview(toNumericId(id, '후기'));
+
+      if (authStore.user?.role === 'FREELANCER') {
+        await Promise.all([fetchFreelancerReviews(), fetchFreelancerReviewTargets()]);
+      } else {
+        await fetchEmployerReviews();
+      }
+    } finally {
+      isSubmittingReview.value = false;
+    }
   }
 
-  function deleteFreelancerToEmployerReview(id: string) {
-    freelancerToEmployerReviews.value = freelancerToEmployerReviews.value.filter((review) => review.id !== id);
+  async function deleteEmployerToFreelancerReview(id: string) {
+    isSubmittingReview.value = true;
+
+    try {
+      await deleteEmployerReview(toNumericId(id, '후기'));
+
+      if (authStore.user?.role === 'EMPLOYER') {
+        await Promise.all([fetchEmployerReviews(), fetchEmployerReviewTargets()]);
+      } else {
+        await fetchFreelancerReviews();
+      }
+    } finally {
+      isSubmittingReview.value = false;
+    }
   }
-
-  function deleteEmployerToFreelancerReview(id: string) {
-    employerToFreelancerReviews.value = employerToFreelancerReviews.value.filter((review) => review.id !== id);
-  }
-
-  loadFromStorage();
-
-  watch(
-    [freelancerToEmployerReviews, employerToFreelancerReviews],
-    () => {
-      persist();
-    },
-    { deep: true }
-  );
 
   return {
     freelancerToEmployerReviews,
     employerToFreelancerReviews,
+    employerReviewTargets,
+    freelancerReviewTargets,
+    isFetchingReviews,
+    reviewFetchError,
+    isFetchingReviewTargets,
+    reviewTargetFetchError,
+    isSubmittingReview,
+    fetchEmployerReviews,
+    fetchFreelancerReviews,
+    fetchEmployerReviewTargets,
+    fetchFreelancerReviewTargets,
     addFreelancerToEmployerReview,
     addEmployerToFreelancerReview,
     updateFreelancerToEmployerReview,

--- a/freebridgefe/src/views/employer/Applications/ApplicationList.vue
+++ b/freebridgefe/src/views/employer/Applications/ApplicationList.vue
@@ -28,11 +28,19 @@ const freelancerStore = useFreelancerStore();
 const rejectingApp = ref<Application | null>(null);
 
 onMounted(async () => {
-  try {
-    await jobStore.fetchJobPostings();
-  } catch (error) {
-    console.error('Failed to load employer jobs for applications view:', error);
+  const [jobsResult, proposalsResult] = await Promise.allSettled([
+    jobStore.fetchJobPostings(),
+    freelancerStore.fetchEmployerProposals(),
+  ]);
+
+  if (jobsResult.status === 'rejected') {
+    console.error('Failed to load employer jobs for applications view:', jobsResult.reason);
     window.alert('공고 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.');
+  }
+
+  if (proposalsResult.status === 'rejected') {
+    console.error('Failed to load employer proposals:', proposalsResult.reason);
+    window.alert('보낸 제안 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.');
   }
 });
 
@@ -213,8 +221,19 @@ const formatDate = (date: Date | string) => {
           <h2 class="text-2xl font-bold">내가 보낸 제안</h2>
         </div>
 
+        <div v-if="freelancerStore.isFetchingProposals" class="text-center py-10 text-white/40">
+          제안 목록을 불러오는 중입니다.
+        </div>
+
+        <div
+          v-else-if="freelancerStore.proposalFetchError"
+          class="mb-4 rounded-2xl border border-red-500/20 bg-red-500/10 px-5 py-4 text-sm text-red-200"
+        >
+          {{ freelancerStore.proposalFetchError }}
+        </div>
+
         <div class="space-y-4">
-          <div v-if="mySentProposals.length === 0" class="text-center py-10 text-white/40">
+          <div v-if="!freelancerStore.isFetchingProposals && mySentProposals.length === 0" class="text-center py-10 text-white/40">
             아직 보낸 제안이 없습니다.
           </div>
 

--- a/freebridgefe/src/views/employer/Freelancers/FreelancerSearchView.vue
+++ b/freebridgefe/src/views/employer/Freelancers/FreelancerSearchView.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import { Search, Filter, Users, Star, DollarSign, SlidersHorizontal, Send } from 'lucide-vue-next';
-import { useFreelancerStore } from '@/stores/freelancerStore';
+import { computed, onMounted, ref } from 'vue';
+import { Search, Filter, Users, Star, DollarSign, SlidersHorizontal, Send, BriefcaseBusiness, ChevronLeft, ChevronRight } from 'lucide-vue-next';
+import { getEmployerFreelancers, type EmployerFreelancerSearchItem } from '@/api/MyPage/employerFreelancerApi';
 import { useFavoritesStore } from '@/stores/favoritesStore';
 import type { User } from '@/types';
 import ProposalModal from '@/views/employer/Recommended/components/ProposalModal.vue';
 
-const freelancerStore = useFreelancerStore();
 const favoritesStore = useFavoritesStore();
+const pageSize = 20;
 
 const searchQueryInput = ref('');
 const selectedSkillInput = ref('ALL');
@@ -20,23 +20,30 @@ const selectedSkill = ref('ALL');
 const minExperience = ref(0);
 const maxMonthlySalary = ref(10000000);
 const favoriteOnly = ref(false);
+const freelancers = ref<EmployerFreelancerSearchItem[]>([]);
+const isLoading = ref(false);
+const loadError = ref<string | null>(null);
+const currentPage = ref(0);
+const totalPages = ref(0);
+const totalElements = ref(0);
 const selectedFreelancer = ref<User | null>(null);
 
 const allSkills = computed(() => {
   const skills = new Set<string>();
-  freelancerStore.freelancers.forEach((freelancer) => {
+  freelancers.value.forEach((freelancer) => {
     freelancer.skills?.forEach((skill) => skills.add(skill));
   });
   return ['ALL', ...Array.from(skills).sort()];
 });
 
-const filteredFreelancers = computed<User[]>(() => {
+const filteredFreelancers = computed<EmployerFreelancerSearchItem[]>(() => {
   const query = searchQuery.value.trim().toLowerCase();
-  return freelancerStore.freelancers.filter((freelancer) => {
+  return freelancers.value.filter((freelancer) => {
     const matchesQuery =
       !query ||
       freelancer.name.toLowerCase().includes(query) ||
-      freelancer.bio?.toLowerCase().includes(query) ||
+      freelancer.job?.toLowerCase().includes(query) ||
+      freelancer.introduction?.toLowerCase().includes(query) ||
       freelancer.skills?.some((skill) => skill.toLowerCase().includes(query));
 
     const matchesSkill =
@@ -44,12 +51,12 @@ const filteredFreelancers = computed<User[]>(() => {
       freelancer.skills?.some((skill) => skill === selectedSkill.value);
 
     const matchesExperience =
-      (freelancer.experience ?? 0) >= minExperience.value;
+      (freelancer.careerYears ?? 0) >= minExperience.value;
 
     const matchesRate =
-      (freelancer.monthlySalary ?? 0) <= maxMonthlySalary.value;
+      (freelancer.wage ?? 0) <= maxMonthlySalary.value;
 
-    const matchesFavorite = !favoriteOnly.value || isFavorite(freelancer.id);
+    const matchesFavorite = !favoriteOnly.value || isFavorite(freelancer.freelancerId);
 
     return matchesQuery && matchesSkill && matchesExperience && matchesRate && matchesFavorite;
   });
@@ -57,19 +64,60 @@ const filteredFreelancers = computed<User[]>(() => {
 
 const formatSkills = (skills?: string[]) => skills?.slice(0, 6) || [];
 
-const isFavorite = (id: string) => favoritesStore.favoriteIds.includes(id);
+const formatMoney = (amount?: number | null) => (amount ?? 0).toLocaleString();
 
-const toggleFavorite = (id: string) => favoritesStore.toggleFavorite(id);
+const getInitial = (name: string) => name?.trim().charAt(0) || '?';
 
-const applyFilters = () => {
+const isFavorite = (id: number) => favoritesStore.favoriteIds.includes(String(id));
+
+const toggleFavorite = (id: number) => favoritesStore.toggleFavorite(String(id));
+
+const toProposalFreelancer = (freelancer: EmployerFreelancerSearchItem): User => ({
+  id: String(freelancer.freelancerId),
+  role: 'FREELANCER',
+  name: freelancer.name,
+  email: 'hidden@example.com',
+  avatar: freelancer.avatarUrl ?? undefined,
+  skills: freelancer.skills,
+  experience: freelancer.careerYears ?? 0,
+  monthlySalary: freelancer.wage ?? 0,
+  bio: freelancer.introduction ?? freelancer.job ?? '',
+});
+
+const loadFreelancers = async () => {
+  isLoading.value = true;
+  loadError.value = null;
+
+  try {
+    const response = await getEmployerFreelancers({
+      page: currentPage.value,
+      size: pageSize,
+      keyword: searchQuery.value || undefined,
+    });
+    freelancers.value = response.items;
+    totalPages.value = response.totalPages;
+    totalElements.value = response.totalElements;
+  } catch (error: any) {
+    freelancers.value = [];
+    totalPages.value = 0;
+    totalElements.value = 0;
+    loadError.value = error?.response?.data?.message || error?.message || '프리랜서 목록을 불러오지 못했습니다.';
+  } finally {
+    isLoading.value = false;
+  }
+};
+
+const applyFilters = async () => {
   searchQuery.value = searchQueryInput.value;
   selectedSkill.value = selectedSkillInput.value;
   minExperience.value = minExperienceInput.value;
   maxMonthlySalary.value = maxMonthlySalaryInput.value;
   favoriteOnly.value = favoriteOnlyInput.value;
+  currentPage.value = 0;
+  await loadFreelancers();
 };
 
-const resetFilters = () => {
+const resetFilters = async () => {
   searchQueryInput.value = '';
   selectedSkillInput.value = 'ALL';
   minExperienceInput.value = 0;
@@ -81,7 +129,25 @@ const resetFilters = () => {
   minExperience.value = 0;
   maxMonthlySalary.value = 10000000;
   favoriteOnly.value = false;
+  currentPage.value = 0;
+  await loadFreelancers();
 };
+
+const canGoPrev = computed(() => currentPage.value > 0);
+const canGoNext = computed(() => currentPage.value + 1 < totalPages.value);
+
+const movePage = async (nextPage: number) => {
+  if (nextPage < 0 || nextPage >= totalPages.value || nextPage === currentPage.value) {
+    return;
+  }
+
+  currentPage.value = nextPage;
+  await loadFreelancers();
+};
+
+onMounted(() => {
+  void loadFreelancers();
+});
 </script>
 
 <template>
@@ -92,6 +158,9 @@ const resetFilters = () => {
         <h1 class="text-3xl md:text-4xl font-bold">프리랜서 찾기</h1>
       </div>
       <p class="text-white/60">전체 프리랜서를 조건별로 검색해보세요</p>
+      <p class="text-sm text-white/40">
+        이름/직무/소개는 서버에서 조회하고, 스킬·경력·희망금액·즐겨찾기는 현재 조회 결과에서 추가 필터링합니다.
+      </p>
 
       <div class="grid gap-4 lg:grid-cols-[2fr_1fr_1fr_1fr_auto] items-stretch">
         <div class="bg-white/5 border border-white/10 rounded-2xl px-4 py-3 flex items-center gap-3">
@@ -172,28 +241,59 @@ const resetFilters = () => {
       </div>
     </div>
 
-    <div v-if="filteredFreelancers.length === 0" class="bg-white/5 border border-white/10 rounded-3xl p-12 text-center text-white/50">
+    <div class="mb-6 flex items-center justify-between gap-4 text-sm text-white/60">
+      <span>검색 결과 {{ totalElements.toLocaleString() }}명</span>
+      <span v-if="totalPages > 0">페이지 {{ currentPage + 1 }} / {{ totalPages }}</span>
+    </div>
+
+    <div v-if="isLoading" class="bg-white/5 border border-white/10 rounded-3xl p-12 text-center text-white/50">
+      프리랜서 목록을 불러오는 중입니다.
+    </div>
+
+    <div v-else-if="loadError" class="bg-red-500/10 border border-red-400/20 rounded-3xl p-12 text-center text-red-200">
+      {{ loadError }}
+    </div>
+
+    <div v-else-if="filteredFreelancers.length === 0" class="bg-white/5 border border-white/10 rounded-3xl p-12 text-center text-white/50">
       조건에 맞는 프리랜서가 없습니다.
     </div>
 
     <div v-else class="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
       <div
         v-for="freelancer in filteredFreelancers"
-        :key="freelancer.id"
+        :key="freelancer.freelancerId"
         class="bg-white/5 border border-white/10 rounded-3xl p-6 hover:bg-white/10 transition-all"
       >
         <div class="flex items-start gap-4 mb-4">
-          <div class="w-14 h-14 rounded-full bg-gradient-to-br from-emerald-400 to-teal-500 flex items-center justify-center text-white text-2xl font-bold">
-            {{ freelancer.name[0] }}
+          <div class="w-14 h-14 rounded-full bg-gradient-to-br from-emerald-400 to-teal-500 overflow-hidden flex items-center justify-center text-white text-2xl font-bold">
+            <img
+              v-if="freelancer.avatarUrl"
+              :src="freelancer.avatarUrl"
+              :alt="`${freelancer.name} 프로필 이미지`"
+              class="h-full w-full object-cover"
+            />
+            <span v-else>{{ getInitial(freelancer.name) }}</span>
           </div>
           <div class="flex-1">
-            <div class="text-xl font-semibold">{{ freelancer.name }}</div>
-            <div class="text-sm text-white/60">{{ freelancer.experience }}년 경력</div>
+            <div class="flex items-center gap-2 flex-wrap">
+              <div class="text-xl font-semibold">{{ freelancer.name }}</div>
+              <span
+                v-if="freelancer.grade"
+                class="px-2 py-0.5 rounded-full border border-emerald-400/20 bg-emerald-400/10 text-xs text-emerald-300"
+              >
+                {{ freelancer.grade }}
+              </span>
+            </div>
+            <div class="mt-1 flex items-center gap-2 text-sm text-white/60">
+              <BriefcaseBusiness class="w-4 h-4" />
+              <span>{{ freelancer.job || '직무 정보 없음' }}</span>
+            </div>
+            <div class="text-sm text-white/60">{{ freelancer.careerYears ?? 0 }}년 경력</div>
           </div>
         </div>
 
         <p class="text-white/70 text-sm mb-4 line-clamp-2 min-h-[40px]">
-          {{ freelancer.bio || '소개가 아직 등록되지 않았습니다.' }}
+          {{ freelancer.introduction || '소개가 아직 등록되지 않았습니다.' }}
         </p>
 
         <div class="flex flex-wrap gap-2 mb-5">
@@ -208,25 +308,25 @@ const resetFilters = () => {
 
         <div class="flex items-center justify-between pt-4 border-t border-white/10">
           <div class="text-sm text-white/60">
-            월급 <span class="text-white font-semibold">{{ freelancer.monthlySalary?.toLocaleString() }}원</span>
+            희망 금액 <span class="text-white font-semibold">{{ formatMoney(freelancer.wage) }}원</span>
           </div>
           <div class="flex items-center gap-2">
             <button
               type="button"
-              @click="toggleFavorite(freelancer.id)"
+              @click="toggleFavorite(freelancer.freelancerId)"
               class="px-3 py-2 rounded-lg border transition-all"
-              :class="isFavorite(freelancer.id)
+              :class="isFavorite(freelancer.freelancerId)
                 ? 'bg-yellow-400/20 border-yellow-400/40 text-yellow-300'
                 : 'bg-white/5 border-white/10 text-white/60 hover:bg-white/10'"
             >
               <Star
                 class="w-4 h-4"
-                :class="isFavorite(freelancer.id) ? 'fill-yellow-400 text-yellow-400' : ''"
+                :class="isFavorite(freelancer.freelancerId) ? 'fill-yellow-400 text-yellow-400' : ''"
               />
             </button>
             <button
               type="button"
-              @click="selectedFreelancer = freelancer"
+              @click="selectedFreelancer = toProposalFreelancer(freelancer)"
               class="px-4 py-2 bg-emerald-400 text-black rounded-lg font-semibold hover:bg-emerald-300 transition-colors flex items-center gap-2"
             >
               <Send class="w-4 h-4" />
@@ -235,6 +335,30 @@ const resetFilters = () => {
           </div>
         </div>
       </div>
+    </div>
+
+    <div v-if="!isLoading && totalPages > 1" class="mt-8 flex items-center justify-center gap-3">
+      <button
+        type="button"
+        @click="movePage(currentPage - 1)"
+        :disabled="!canGoPrev"
+        class="flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-white transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        <ChevronLeft class="h-4 w-4" />
+        이전
+      </button>
+      <div class="rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm text-white/70">
+        {{ currentPage + 1 }} / {{ totalPages }}
+      </div>
+      <button
+        type="button"
+        @click="movePage(currentPage + 1)"
+        :disabled="!canGoNext"
+        class="flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-white transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        다음
+        <ChevronRight class="h-4 w-4" />
+      </button>
     </div>
 
     <ProposalModal

--- a/freebridgefe/src/views/employer/Recommended/components/ProposalModal.vue
+++ b/freebridgefe/src/views/employer/Recommended/components/ProposalModal.vue
@@ -21,6 +21,7 @@ const jobStore = useJobStore();
 
 const message = ref('');
 const selectedJobId = ref('');
+const isSubmitting = ref(false);
 
 onMounted(async () => {
   try {
@@ -53,17 +54,7 @@ const isSubmitDisabled = computed(
   () => employerJobs.value.length === 0 || !selectedJobId.value || !message.value.trim()
 );
 
-const getNormalizedEmployerId = () => {
-  if (!authStore.user) return '';
-
-  const rawId = String(authStore.user.id);
-  if (/^[ef]\d+$/i.test(rawId)) {
-    return rawId;
-  }
-  return `e${rawId}`;
-};
-
-const handleSubmit = () => {
+const handleSubmit = async () => {
   if (!authStore.user) return;
   if (!selectedJobId.value) {
     alert('제안할 프로젝트를 선택해주세요.');
@@ -76,19 +67,27 @@ const handleSubmit = () => {
     return;
   }
 
-  // Use store action to add proposal
-  freelancerStore.addProposal({
-    employerId: getNormalizedEmployerId(),
-    employerName: authStore.user.companyName || authStore.user.name,
-    freelancerId: props.freelancer.id,
-    freelancerName: props.freelancer.name,
-    jobId: selectedJobId.value,
-    message: trimmedMessage,
-    status: 'PENDING',
-  });
+  isSubmitting.value = true;
 
-  alert(`${props.freelancer.name}님께 제안을 보냈습니다!`);
-  emit('close');
+  try {
+    await freelancerStore.addProposal({
+      employerId: String(authStore.user.id),
+      employerName: authStore.user.companyName || authStore.user.name,
+      freelancerId: String(props.freelancer.id),
+      freelancerName: props.freelancer.name,
+      jobId: selectedJobId.value,
+      message: trimmedMessage,
+      status: 'PENDING',
+    });
+
+    alert(`${props.freelancer.name}님께 제안을 보냈습니다!`);
+    emit('close');
+  } catch (error: any) {
+    console.error('Failed to send proposal:', error);
+    alert(error?.response?.data?.message || error?.message || '제안 전송에 실패했습니다.');
+  } finally {
+    isSubmitting.value = false;
+  }
 };
 </script>
 
@@ -136,7 +135,7 @@ const handleSubmit = () => {
           <select
             v-model="selectedJobId"
             class="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-2xl focus:outline-none focus:border-blue-500 text-white"
-            :disabled="employerJobs.length === 0"
+            :disabled="employerJobs.length === 0 || isSubmitting"
             required
           >
             <option value="" disabled class="text-black">프로젝트를 선택하세요</option>
@@ -180,15 +179,15 @@ const handleSubmit = () => {
           </button>
           <button
             type="submit"
-            :disabled="isSubmitDisabled"
+            :disabled="isSubmitDisabled || isSubmitting"
             class="flex-1 px-6 py-3 bg-gradient-to-r from-blue-500 to-purple-500 text-white rounded-2xl hover:shadow-xl transition-all font-semibold flex items-center justify-center gap-2"
-            :class="isSubmitDisabled ? 'opacity-50 cursor-not-allowed hover:shadow-none' : ''"
+            :class="(isSubmitDisabled || isSubmitting) ? 'opacity-50 cursor-not-allowed hover:shadow-none' : ''"
             v-motion
             :hover="{ scale: 1.02 }"
             :tap="{ scale: 0.98 }"
           >
             <Send class="w-5 h-5" />
-            제안 보내기
+            {{ isSubmitting ? '전송 중...' : '제안 보내기' }}
           </button>
         </div>
       </form>

--- a/freebridgefe/src/views/employer/Review/ReviewList.vue
+++ b/freebridgefe/src/views/employer/Review/ReviewList.vue
@@ -1,6 +1,15 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import { Star, MessageSquareQuote, UserCheck, ClipboardEdit, Pencil, Trash2, X } from 'lucide-vue-next';
+import { computed, onMounted, ref } from 'vue';
+import {
+  Star,
+  MessageSquareQuote,
+  UserCheck,
+  ClipboardEdit,
+  Pencil,
+  Trash2,
+  X,
+  LoaderCircle,
+} from 'lucide-vue-next';
 import { useReviewStore, type EmployerToFreelancerReview } from '@/stores/reviewStore';
 
 const reviewStore = useReviewStore();
@@ -28,11 +37,15 @@ const freelancerToEmployerReviews = computed(() =>
   reviewStore.freelancerToEmployerReviews.map((review) => ({
     ...review,
     reviewerName: review.freelancerName,
-  }))
+  })),
 );
+const isLoading = computed(() => reviewStore.isFetchingReviews);
+const isSubmitting = computed(() => reviewStore.isSubmittingReview);
+const fetchError = computed(() => reviewStore.reviewFetchError);
 
 const editingReviewId = ref<string | null>(null);
 const editForm = ref<EmployerEditableReview | null>(null);
+const actionError = ref('');
 
 const toReviewForm = (review: EmployerToFreelancerReview) =>
   JSON.parse(JSON.stringify(review)) as EmployerEditableReview;
@@ -40,44 +53,79 @@ const toReviewForm = (review: EmployerToFreelancerReview) =>
 const startEdit = (review: EmployerToFreelancerReview) => {
   editingReviewId.value = review.id;
   editForm.value = toReviewForm(review);
+  actionError.value = '';
 };
 
 const cancelEdit = () => {
   editingReviewId.value = null;
   editForm.value = null;
+  actionError.value = '';
 };
 
-const saveEdit = () => {
-  if (!editForm.value) return;
-  if (!window.confirm('후기를 수정하시겠습니까?')) return;
+const loadReviews = async () => {
+  actionError.value = '';
 
-  reviewStore.updateEmployerToFreelancerReview(editForm.value.id, {
-    freelancerName: editForm.value.freelancerName,
-    projectName: editForm.value.projectName,
-    language: editForm.value.language,
-    framework: editForm.value.framework,
-    debugging: editForm.value.debugging,
-    communication: editForm.value.communication,
-    schedule: editForm.value.schedule,
-    dispute: editForm.value.dispute,
-    comment: editForm.value.comment,
-  });
-
-  cancelEdit();
-};
-
-const deleteReview = (id: string) => {
-  if (!window.confirm('후기를 삭제하시겠습니까?')) return;
-  reviewStore.deleteEmployerToFreelancerReview(id);
-  if (editingReviewId.value === id) {
-    cancelEdit();
+  try {
+    await reviewStore.fetchEmployerReviews();
+  } catch {
+    actionError.value = reviewStore.reviewFetchError || '후기 목록을 불러오지 못했습니다.';
   }
 };
+
+const saveEdit = async () => {
+  if (!editForm.value) {
+    return;
+  }
+
+  if (!window.confirm('후기를 수정하시겠습니까?')) {
+    return;
+  }
+
+  actionError.value = '';
+
+  try {
+    await reviewStore.updateEmployerToFreelancerReview(editForm.value.id, {
+      language: editForm.value.language,
+      framework: editForm.value.framework,
+      debugging: editForm.value.debugging,
+      communication: editForm.value.communication,
+      schedule: editForm.value.schedule,
+      dispute: editForm.value.dispute,
+      comment: editForm.value.comment,
+    });
+
+    cancelEdit();
+  } catch (error) {
+    actionError.value =
+      error instanceof Error ? error.message : '후기를 수정하지 못했습니다.';
+  }
+};
+
+const deleteReview = async (id: string) => {
+  if (!window.confirm('후기를 삭제하시겠습니까?')) {
+    return;
+  }
+
+  actionError.value = '';
+
+  try {
+    await reviewStore.deleteEmployerToFreelancerReview(id);
+    if (editingReviewId.value === id) {
+      cancelEdit();
+    }
+  } catch (error) {
+    actionError.value =
+      error instanceof Error ? error.message : '후기를 삭제하지 못했습니다.';
+  }
+};
+
+onMounted(() => {
+  void loadReviews();
+});
 </script>
 
 <template>
   <div class="max-w-[1400px] mx-auto px-4 md:px-8 py-12 font-sans text-white">
-    <!-- Header -->
     <div
       class="flex flex-col md:flex-row items-start md:items-center justify-between mb-12 gap-4"
       v-motion
@@ -106,7 +154,13 @@ const deleteReview = (id: string) => {
       </RouterLink>
     </div>
 
-    <!-- Reviews -->
+    <div v-if="isLoading" class="flex items-center gap-2 text-white/60 mb-10">
+      <LoaderCircle class="w-5 h-5 animate-spin" />
+      후기 목록을 불러오는 중입니다.
+    </div>
+    <div v-else-if="fetchError" class="text-red-300 mb-10">{{ fetchError }}</div>
+    <div v-if="actionError" class="text-red-300 mb-10">{{ actionError }}</div>
+
     <div class="grid gap-8">
       <div
         class="bg-white/5 backdrop-blur-xl rounded-3xl border border-white/10 p-8"
@@ -119,6 +173,9 @@ const deleteReview = (id: string) => {
           <h2 class="text-2xl font-bold">내가 남긴 후기</h2>
         </div>
         <div class="space-y-4">
+          <div v-if="!isLoading && employerToFreelancerReviews.length === 0" class="text-center py-12 text-white/40">
+            아직 작성한 후기가 없습니다.
+          </div>
           <div
             v-for="(review, index) in employerToFreelancerReviews"
             :key="review.id"
@@ -136,7 +193,8 @@ const deleteReview = (id: string) => {
                 {{ new Date(review.createdAt).toLocaleDateString('ko-KR') }}
                 <button
                   type="button"
-                  class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-white/10 text-white/80 hover:bg-white/20 transition-colors"
+                  class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-white/10 text-white/80 hover:bg-white/20 transition-colors disabled:opacity-50"
+                  :disabled="isSubmitting"
                   @click="startEdit(review)"
                 >
                   <Pencil class="w-4 h-4" />
@@ -144,7 +202,8 @@ const deleteReview = (id: string) => {
                 </button>
                 <button
                   type="button"
-                  class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-red-500/10 text-red-300 hover:bg-red-500/20 transition-colors"
+                  class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-red-500/10 text-red-300 hover:bg-red-500/20 transition-colors disabled:opacity-50"
+                  :disabled="isSubmitting"
                   @click="deleteReview(review.id)"
                 >
                   <Trash2 class="w-4 h-4" />
@@ -196,7 +255,8 @@ const deleteReview = (id: string) => {
                       v-for="star in 5"
                       :key="star"
                       type="button"
-                      class="transition-transform hover:scale-110"
+                      class="transition-transform hover:scale-110 disabled:cursor-not-allowed"
+                      :disabled="isSubmitting"
                       @click="editForm && (editForm[item.key] = star)"
                     >
                       <Star
@@ -213,7 +273,8 @@ const deleteReview = (id: string) => {
                 <textarea
                   v-model="editForm.comment"
                   rows="4"
-                  class="bg-black/30 border border-white/10 rounded-2xl px-4 py-3 text-white/90 focus:outline-none focus:ring-2 focus:ring-white/30"
+                  :disabled="isSubmitting"
+                  class="bg-black/30 border border-white/10 rounded-2xl px-4 py-3 text-white/90 focus:outline-none focus:ring-2 focus:ring-white/30 disabled:opacity-50"
                   placeholder="후기 내용을 수정해 주세요."
                 ></textarea>
               </label>
@@ -221,15 +282,21 @@ const deleteReview = (id: string) => {
               <div class="flex flex-col md:flex-row md:items-center gap-3">
                 <button
                   type="button"
+                  :disabled="isSubmitting"
                   @click="saveEdit"
-                  class="px-6 py-3 bg-white text-black rounded-full font-semibold hover:scale-105 transition-transform"
+                  class="px-6 py-3 bg-white text-black rounded-full font-semibold hover:scale-105 transition-transform disabled:opacity-50 disabled:hover:scale-100"
                 >
-                  수정 저장
+                  <span v-if="!isSubmitting">수정 저장</span>
+                  <span v-else class="inline-flex items-center gap-2">
+                    <LoaderCircle class="w-4 h-4 animate-spin" />
+                    저장 중
+                  </span>
                 </button>
                 <button
                   type="button"
+                  :disabled="isSubmitting"
                   @click="cancelEdit"
-                  class="px-6 py-3 bg-white/10 text-white rounded-full font-semibold hover:bg-white/20 transition-colors inline-flex items-center gap-2"
+                  class="px-6 py-3 bg-white/10 text-white rounded-full font-semibold hover:bg-white/20 transition-colors inline-flex items-center gap-2 disabled:opacity-50"
                 >
                   <X class="w-4 h-4" />
                   취소
@@ -251,6 +318,9 @@ const deleteReview = (id: string) => {
           <h2 class="text-2xl font-bold">프리랜서가 남긴 후기</h2>
         </div>
         <div class="space-y-4">
+          <div v-if="!isLoading && freelancerToEmployerReviews.length === 0" class="text-center py-12 text-white/40">
+            아직 프리랜서가 남긴 후기가 없습니다.
+          </div>
           <div
             v-for="(review, index) in freelancerToEmployerReviews"
             :key="review.id"

--- a/freebridgefe/src/views/employer/Review/ReviewWrite.vue
+++ b/freebridgefe/src/views/employer/Review/ReviewWrite.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue';
-import { Star, ClipboardEdit, ArrowLeft } from 'lucide-vue-next';
-import { useAuthStore } from '@/stores/authStore';
+import { computed, onMounted, reactive, ref } from 'vue';
+import { Star, ClipboardEdit, ArrowLeft, LoaderCircle } from 'lucide-vue-next';
 import { useReviewStore } from '@/stores/reviewStore';
 
 const evaluationItems = [
@@ -14,17 +13,12 @@ const evaluationItems = [
 ] as const;
 
 type ReviewRatingKey = typeof evaluationItems[number]['key'];
-
 type ReviewFormRatings = Record<ReviewRatingKey, number>;
 
-const employerProjects = [
-  { id: 'p1', title: '대시보드 고도화', freelancerName: '김프리' },
-  { id: 'p2', title: '브랜딩 UI 리뉴얼', freelancerName: '박디자인' },
-  { id: 'p3', title: '데이터 파이프라인 개선', freelancerName: '오데이터' },
-];
+const reviewStore = useReviewStore();
 
 const form = reactive({
-  projectId: '',
+  targetKey: '',
   ratings: {
     language: 0,
     framework: 0,
@@ -38,15 +32,22 @@ const form = reactive({
 
 const formError = ref('');
 const formSuccess = ref('');
-const authStore = useAuthStore();
-const reviewStore = useReviewStore();
 
-const selectedProject = computed(() => employerProjects.find((p) => p.id === form.projectId));
+const reviewTargets = computed(() => reviewStore.employerReviewTargets);
+const isLoadingTargets = computed(() => reviewStore.isFetchingReviewTargets);
+const targetFetchError = computed(() => reviewStore.reviewTargetFetchError);
+const isSubmitting = computed(() => reviewStore.isSubmittingReview);
+const selectedTarget = computed(() =>
+  reviewTargets.value.find((target) => target.key === form.targetKey),
+);
 
 const overallRating = computed(() => {
   const values = Object.values(form.ratings);
-  if (values.some((v) => v === 0)) return 0;
-  const sum = values.reduce((acc, v) => acc + v, 0);
+  if (values.some((value) => value === 0)) {
+    return 0;
+  }
+
+  const sum = values.reduce((acc, value) => acc + value, 0);
   return sum / values.length;
 });
 
@@ -55,7 +56,7 @@ const setRating = (field: ReviewRatingKey, value: number) => {
 };
 
 const resetForm = () => {
-  form.projectId = '';
+  form.targetKey = '';
   form.ratings = {
     language: 0,
     framework: 0,
@@ -67,16 +68,24 @@ const resetForm = () => {
   form.comment = '';
 };
 
-const handleSubmit = () => {
+const loadReviewTargets = async () => {
+  try {
+    await reviewStore.fetchEmployerReviewTargets();
+  } catch {
+    formError.value = reviewStore.reviewTargetFetchError || '후기 작성 대상을 불러오지 못했습니다.';
+  }
+};
+
+const handleSubmit = async () => {
   formError.value = '';
   formSuccess.value = '';
 
-  if (!form.projectId) {
+  if (!selectedTarget.value) {
     formError.value = '프로젝트를 선택해 주세요.';
     return;
   }
 
-  if (Object.values(form.ratings).some((v) => v === 0)) {
+  if (Object.values(form.ratings).some((value) => value === 0)) {
     formError.value = '모든 평가 항목을 입력해 주세요.';
     return;
   }
@@ -90,28 +99,33 @@ const handleSubmit = () => {
     return;
   }
 
-  if (!selectedProject.value) {
-    formError.value = '프로젝트 정보를 찾을 수 없습니다.';
-    return;
+  try {
+    await reviewStore.addEmployerToFreelancerReview({
+      projectId: selectedTarget.value.projectId,
+      employerId: '',
+      freelancerId: selectedTarget.value.counterpartyId,
+      freelancerName: selectedTarget.value.counterpartyName,
+      projectName: selectedTarget.value.projectName,
+      language: form.ratings.language,
+      framework: form.ratings.framework,
+      debugging: form.ratings.debugging,
+      communication: form.ratings.communication,
+      schedule: form.ratings.schedule,
+      dispute: form.ratings.dispute,
+      comment: form.comment.trim(),
+    });
+
+    formSuccess.value = '후기가 등록되었습니다.';
+    resetForm();
+  } catch (error) {
+    formError.value =
+      error instanceof Error ? error.message : '후기를 등록하지 못했습니다.';
   }
-
-  reviewStore.addEmployerToFreelancerReview({
-    employerId: authStore.user?.id,
-    employerName: authStore.user?.companyName || authStore.user?.name || '고용주',
-    freelancerName: selectedProject.value.freelancerName,
-    projectName: selectedProject.value.title,
-    language: form.ratings.language,
-    framework: form.ratings.framework,
-    debugging: form.ratings.debugging,
-    communication: form.ratings.communication,
-    schedule: form.ratings.schedule,
-    dispute: form.ratings.dispute,
-    comment: form.comment.trim(),
-  });
-
-  formSuccess.value = '후기가 등록되었습니다.';
-  resetForm();
 };
+
+onMounted(() => {
+  void loadReviewTargets();
+});
 </script>
 
 <template>
@@ -147,12 +161,15 @@ const handleSubmit = () => {
         <label class="flex flex-col gap-2">
           <span class="text-sm text-white/60">프로젝트 선택</span>
           <select
-            v-model="form.projectId"
-            class="bg-black/30 border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-white/30"
+            v-model="form.targetKey"
+            :disabled="isLoadingTargets || isSubmitting"
+            class="bg-black/30 border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-white/30 disabled:opacity-50"
           >
-            <option value="" disabled>프로젝트를 선택하세요</option>
-            <option v-for="project in employerProjects" :key="project.id" :value="project.id">
-              {{ project.title }} · {{ project.freelancerName }}
+            <option value="" disabled>
+              {{ isLoadingTargets ? '프로젝트를 불러오는 중...' : '프로젝트를 선택하세요' }}
+            </option>
+            <option v-for="target in reviewTargets" :key="target.key" :value="target.key">
+              {{ target.projectName }} · {{ target.counterpartyName }}
             </option>
           </select>
         </label>
@@ -160,9 +177,20 @@ const handleSubmit = () => {
         <div class="flex flex-col gap-2">
           <span class="text-sm text-white/60">선택된 프리랜서</span>
           <div class="bg-black/20 border border-white/10 rounded-xl px-4 py-3 text-white/80">
-            {{ selectedProject?.freelancerName || '프로젝트를 선택해 주세요' }}
+            {{ selectedTarget?.counterpartyName || '프로젝트를 선택해 주세요' }}
           </div>
         </div>
+      </div>
+
+      <div v-if="isLoadingTargets" class="flex items-center gap-2 text-sm text-white/60 mb-6">
+        <LoaderCircle class="w-4 h-4 animate-spin" />
+        후기 작성 대상을 불러오는 중입니다.
+      </div>
+      <div v-else-if="targetFetchError" class="text-sm text-red-300 mb-6">
+        {{ targetFetchError }}
+      </div>
+      <div v-else-if="reviewTargets.length === 0" class="text-sm text-white/50 mb-6">
+        후기 작성 가능한 진행 중 프로젝트가 없습니다.
       </div>
 
       <div class="grid md:grid-cols-2 gap-6 mb-6">
@@ -180,7 +208,8 @@ const handleSubmit = () => {
               v-for="star in 5"
               :key="star"
               type="button"
-              class="transition-transform hover:scale-110"
+              class="transition-transform hover:scale-110 disabled:cursor-not-allowed"
+              :disabled="isSubmitting"
               @click="setRating(item.key, star)"
             >
               <Star
@@ -197,7 +226,8 @@ const handleSubmit = () => {
         <textarea
           v-model="form.comment"
           rows="4"
-          class="bg-black/30 border border-white/10 rounded-2xl px-4 py-3 text-white/90 focus:outline-none focus:ring-2 focus:ring-white/30"
+          :disabled="isSubmitting"
+          class="bg-black/30 border border-white/10 rounded-2xl px-4 py-3 text-white/90 focus:outline-none focus:ring-2 focus:ring-white/30 disabled:opacity-50"
           placeholder="프로젝트 진행 경험과 느낀 점을 작성해 주세요."
         ></textarea>
       </label>
@@ -208,15 +238,21 @@ const handleSubmit = () => {
         </div>
         <button
           type="button"
+          :disabled="isSubmitting || isLoadingTargets || reviewTargets.length === 0"
           @click="handleSubmit"
-          class="px-6 py-3 bg-white text-black rounded-full font-semibold hover:scale-105 transition-transform"
+          class="px-6 py-3 bg-white text-black rounded-full font-semibold hover:scale-105 transition-transform disabled:opacity-50 disabled:hover:scale-100"
         >
-          후기 등록
+          <span v-if="!isSubmitting">후기 등록</span>
+          <span v-else class="inline-flex items-center gap-2">
+            <LoaderCircle class="w-4 h-4 animate-spin" />
+            등록 중
+          </span>
         </button>
         <button
           type="button"
+          :disabled="isSubmitting"
           @click="resetForm"
-          class="px-6 py-3 bg-white/10 text-white rounded-full font-semibold hover:bg-white/20 transition-colors"
+          class="px-6 py-3 bg-white/10 text-white rounded-full font-semibold hover:bg-white/20 transition-colors disabled:opacity-50"
         >
           초기화
         </button>

--- a/freebridgefe/src/views/freelancer/Applications/MyApplications.vue
+++ b/freebridgefe/src/views/freelancer/Applications/MyApplications.vue
@@ -24,11 +24,19 @@ const jobStore = useJobStore();
 const freelancerStore = useFreelancerStore();
 
 onMounted(async () => {
-  try {
-    await jobStore.fetchJobPostings();
-  } catch (error) {
-    console.error('Failed to load freelancer jobs for application history:', error);
+  const [jobsResult, proposalsResult] = await Promise.allSettled([
+    jobStore.fetchJobPostings(),
+    freelancerStore.fetchFreelancerProposals(),
+  ]);
+
+  if (jobsResult.status === 'rejected') {
+    console.error('Failed to load freelancer jobs for application history:', jobsResult.reason);
     window.alert('공고 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.');
+  }
+
+  if (proposalsResult.status === 'rejected') {
+    console.error('Failed to load freelancer proposals:', proposalsResult.reason);
+    window.alert('받은 제안 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.');
   }
 });
 
@@ -95,33 +103,48 @@ const formatDate = (date: Date | string) => {
 
 const actionFeedback = ref<{ type: 'success' | 'error'; message: string } | null>(null);
 
-const handleAcceptProposal = (proposalId: string) => {
+const handleAcceptProposal = async (proposalId: string) => {
   if (!window.confirm('이 제안을 수락하시겠습니까?')) return;
-  const roomId = freelancerStore.updateProposalStatus(proposalId, 'ACCEPTED');
-  if (!roomId) {
+
+  try {
+    const roomId = await freelancerStore.updateProposalStatus(proposalId, 'ACCEPTED');
+    if (!roomId) {
+      actionFeedback.value = { type: 'error', message: '제안 상태 변경에 실패했습니다. 다시 시도해 주세요.' };
+      alert('제안 상태 변경에 실패했습니다.');
+      return;
+    }
+
+    const shouldMove = confirm('채팅방이 생성되었습니다. 이동하겠습니까?');
+    if (shouldMove) {
+      router.push('/chat');
+    }
+    actionFeedback.value = { type: 'success', message: '제안을 수락했습니다. 상태가 수락됨으로 변경되었습니다.' };
+    alert('제안을 수락했습니다.');
+  } catch (error) {
+    console.error('Failed to accept proposal:', error);
     actionFeedback.value = { type: 'error', message: '제안 상태 변경에 실패했습니다. 다시 시도해 주세요.' };
     alert('제안 상태 변경에 실패했습니다.');
-    return;
   }
-  const shouldMove = confirm('채팅방이 생성되었습니다. 이동하겠습니까?');
-  if (shouldMove) {
-    router.push('/chat');
-  }
-  actionFeedback.value = { type: 'success', message: '제안을 수락했습니다. 상태가 수락됨으로 변경되었습니다.' };
-  alert('제안을 수락했습니다.');
 };
 
-const handleRejectProposal = (proposalId: string) => {
-  const reason = window.prompt('거절 사유를 입력해 주세요. (선택)');
-  if (reason === null) return;
-  const updated = freelancerStore.updateProposalStatus(proposalId, 'REJECTED', reason.trim() || undefined);
-  if (!updated) {
+const handleRejectProposal = async (proposalId: string) => {
+  if (!window.confirm('이 제안을 거절하시겠습니까?')) return;
+
+  try {
+    const updated = await freelancerStore.updateProposalStatus(proposalId, 'REJECTED');
+    if (!updated) {
+      actionFeedback.value = { type: 'error', message: '제안 상태 변경에 실패했습니다. 다시 시도해 주세요.' };
+      alert('제안 상태 변경에 실패했습니다.');
+      return;
+    }
+
+    actionFeedback.value = { type: 'success', message: '제안을 거절했습니다. 상태가 거절됨으로 변경되었습니다.' };
+    alert('제안을 거절했습니다.');
+  } catch (error) {
+    console.error('Failed to reject proposal:', error);
     actionFeedback.value = { type: 'error', message: '제안 상태 변경에 실패했습니다. 다시 시도해 주세요.' };
     alert('제안 상태 변경에 실패했습니다.');
-    return;
   }
-  actionFeedback.value = { type: 'success', message: '제안을 거절했습니다. 상태가 거절됨으로 변경되었습니다.' };
-  alert('제안을 거절했습니다.');
 };
 </script>
 
@@ -269,8 +292,19 @@ const handleRejectProposal = (proposalId: string) => {
           <h2 class="text-2xl font-bold">기업이 보낸 제안</h2>
         </div>
 
+        <div v-if="freelancerStore.isFetchingProposals" class="text-center py-10 text-white/40">
+          제안 목록을 불러오는 중입니다.
+        </div>
+
+        <div
+          v-else-if="freelancerStore.proposalFetchError"
+          class="mb-4 rounded-2xl border border-red-500/20 bg-red-500/10 px-5 py-4 text-sm text-red-200"
+        >
+          {{ freelancerStore.proposalFetchError }}
+        </div>
+
         <div class="space-y-4">
-          <div v-if="receivedProposals.length === 0" class="text-center py-10 text-white/40">
+          <div v-if="!freelancerStore.isFetchingProposals && receivedProposals.length === 0" class="text-center py-10 text-white/40">
             아직 받은 제안이 없습니다.
           </div>
 

--- a/freebridgefe/src/views/freelancer/Review/ReviewList.vue
+++ b/freebridgefe/src/views/freelancer/Review/ReviewList.vue
@@ -1,6 +1,15 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue';
-import { Star, MessageSquareQuote, UserCheck, ClipboardEdit, Pencil, Trash2, X } from 'lucide-vue-next';
+import { computed, onMounted, ref } from 'vue';
+import {
+  Star,
+  MessageSquareQuote,
+  UserCheck,
+  ClipboardEdit,
+  Pencil,
+  Trash2,
+  X,
+  LoaderCircle,
+} from 'lucide-vue-next';
 import { useReviewStore, type FreelancerToEmployerReview } from '@/stores/reviewStore';
 
 const reviewStore = useReviewStore();
@@ -28,11 +37,15 @@ const employerToFreelancerReviews = computed(() =>
   reviewStore.employerToFreelancerReviews.map((review) => ({
     ...review,
     reviewerName: review.employerName,
-  }))
+  })),
 );
+const isLoading = computed(() => reviewStore.isFetchingReviews);
+const isSubmitting = computed(() => reviewStore.isSubmittingReview);
+const fetchError = computed(() => reviewStore.reviewFetchError);
 
 const editingReviewId = ref<string | null>(null);
 const editForm = ref<FreelancerEditableReview | null>(null);
+const actionError = ref('');
 
 const toReviewForm = (review: FreelancerToEmployerReview) =>
   JSON.parse(JSON.stringify(review)) as FreelancerEditableReview;
@@ -40,41 +53,76 @@ const toReviewForm = (review: FreelancerToEmployerReview) =>
 const startEdit = (review: FreelancerToEmployerReview) => {
   editingReviewId.value = review.id;
   editForm.value = toReviewForm(review);
+  actionError.value = '';
 };
 
 const cancelEdit = () => {
   editingReviewId.value = null;
   editForm.value = null;
+  actionError.value = '';
 };
 
-const saveEdit = () => {
-  if (!editForm.value) return;
-  if (!window.confirm('후기를 수정하시겠습니까?')) return;
+const loadReviews = async () => {
+  actionError.value = '';
 
-  reviewStore.updateFreelancerToEmployerReview(editForm.value.id, {
-    companyName: editForm.value.companyName,
-    projectName: editForm.value.projectName,
-    atmosphere: editForm.value.atmosphere,
-    requirementDetail: editForm.value.requirementDetail,
-    schedule: editForm.value.schedule,
-    comment: editForm.value.comment,
-  });
-
-  cancelEdit();
-};
-
-const deleteReview = (id: string) => {
-  if (!window.confirm('후기를 삭제하시겠습니까?')) return;
-  reviewStore.deleteFreelancerToEmployerReview(id);
-  if (editingReviewId.value === id) {
-    cancelEdit();
+  try {
+    await reviewStore.fetchFreelancerReviews();
+  } catch {
+    actionError.value = reviewStore.reviewFetchError || '후기 목록을 불러오지 못했습니다.';
   }
 };
+
+const saveEdit = async () => {
+  if (!editForm.value) {
+    return;
+  }
+
+  if (!window.confirm('후기를 수정하시겠습니까?')) {
+    return;
+  }
+
+  actionError.value = '';
+
+  try {
+    await reviewStore.updateFreelancerToEmployerReview(editForm.value.id, {
+      atmosphere: editForm.value.atmosphere,
+      requirementDetail: editForm.value.requirementDetail,
+      schedule: editForm.value.schedule,
+      comment: editForm.value.comment,
+    });
+
+    cancelEdit();
+  } catch (error) {
+    actionError.value =
+      error instanceof Error ? error.message : '후기를 수정하지 못했습니다.';
+  }
+};
+
+const deleteReview = async (id: string) => {
+  if (!window.confirm('후기를 삭제하시겠습니까?')) {
+    return;
+  }
+
+  actionError.value = '';
+
+  try {
+    await reviewStore.deleteFreelancerToEmployerReview(id);
+    if (editingReviewId.value === id) {
+      cancelEdit();
+    }
+  } catch (error) {
+    actionError.value =
+      error instanceof Error ? error.message : '후기를 삭제하지 못했습니다.';
+  }
+};
+
+onMounted(() => {
+  void loadReviews();
+});
 </script>
 
 <template>
   <div class="max-w-[1400px] mx-auto px-4 md:px-8 py-12 font-sans text-white">
-    <!-- Header -->
     <div
       class="flex flex-col md:flex-row items-start md:items-center justify-between mb-12 gap-4"
       v-motion
@@ -103,7 +151,13 @@ const deleteReview = (id: string) => {
       </RouterLink>
     </div>
 
-    <!-- Reviews -->
+    <div v-if="isLoading" class="flex items-center gap-2 text-white/60 mb-10">
+      <LoaderCircle class="w-5 h-5 animate-spin" />
+      후기 목록을 불러오는 중입니다.
+    </div>
+    <div v-else-if="fetchError" class="text-red-300 mb-10">{{ fetchError }}</div>
+    <div v-if="actionError" class="text-red-300 mb-10">{{ actionError }}</div>
+
     <div class="grid gap-8">
       <div
         class="bg-white/5 backdrop-blur-xl rounded-3xl border border-white/10 p-8"
@@ -116,8 +170,8 @@ const deleteReview = (id: string) => {
           <h2 class="text-2xl font-bold">내가 남긴 후기</h2>
         </div>
         <div class="space-y-4">
-          <div v-if="freelancerToEmployerReviews.length === 0" class="text-center py-12 text-white/40">
-            아직 작성된 후기가 없습니다.
+          <div v-if="!isLoading && freelancerToEmployerReviews.length === 0" class="text-center py-12 text-white/40">
+            아직 작성한 후기가 없습니다.
           </div>
           <div
             v-for="(review, index) in freelancerToEmployerReviews"
@@ -136,7 +190,8 @@ const deleteReview = (id: string) => {
                 {{ new Date(review.createdAt).toLocaleDateString('ko-KR') }}
                 <button
                   type="button"
-                  class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-white/10 text-white/80 hover:bg-white/20 transition-colors"
+                  class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-white/10 text-white/80 hover:bg-white/20 transition-colors disabled:opacity-50"
+                  :disabled="isSubmitting"
                   @click="startEdit(review)"
                 >
                   <Pencil class="w-4 h-4" />
@@ -144,7 +199,8 @@ const deleteReview = (id: string) => {
                 </button>
                 <button
                   type="button"
-                  class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-red-500/10 text-red-300 hover:bg-red-500/20 transition-colors"
+                  class="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-red-500/10 text-red-300 hover:bg-red-500/20 transition-colors disabled:opacity-50"
+                  :disabled="isSubmitting"
                   @click="deleteReview(review.id)"
                 >
                   <Trash2 class="w-4 h-4" />
@@ -196,7 +252,8 @@ const deleteReview = (id: string) => {
                       v-for="star in 5"
                       :key="star"
                       type="button"
-                      class="transition-transform hover:scale-110"
+                      class="transition-transform hover:scale-110 disabled:cursor-not-allowed"
+                      :disabled="isSubmitting"
                       @click="editForm && (editForm[item.key] = star)"
                     >
                       <Star
@@ -213,7 +270,8 @@ const deleteReview = (id: string) => {
                 <textarea
                   v-model="editForm.comment"
                   rows="4"
-                  class="bg-black/30 border border-white/10 rounded-2xl px-4 py-3 text-white/90 focus:outline-none focus:ring-2 focus:ring-white/30"
+                  :disabled="isSubmitting"
+                  class="bg-black/30 border border-white/10 rounded-2xl px-4 py-3 text-white/90 focus:outline-none focus:ring-2 focus:ring-white/30 disabled:opacity-50"
                   placeholder="후기 내용을 수정해 주세요."
                 ></textarea>
               </label>
@@ -221,15 +279,21 @@ const deleteReview = (id: string) => {
               <div class="flex flex-col md:flex-row md:items-center gap-3">
                 <button
                   type="button"
+                  :disabled="isSubmitting"
                   @click="saveEdit"
-                  class="px-6 py-3 bg-white text-black rounded-full font-semibold hover:scale-105 transition-transform"
+                  class="px-6 py-3 bg-white text-black rounded-full font-semibold hover:scale-105 transition-transform disabled:opacity-50 disabled:hover:scale-100"
                 >
-                  수정 저장
+                  <span v-if="!isSubmitting">수정 저장</span>
+                  <span v-else class="inline-flex items-center gap-2">
+                    <LoaderCircle class="w-4 h-4 animate-spin" />
+                    저장 중
+                  </span>
                 </button>
                 <button
                   type="button"
+                  :disabled="isSubmitting"
                   @click="cancelEdit"
-                  class="px-6 py-3 bg-white/10 text-white rounded-full font-semibold hover:bg-white/20 transition-colors inline-flex items-center gap-2"
+                  class="px-6 py-3 bg-white/10 text-white rounded-full font-semibold hover:bg-white/20 transition-colors inline-flex items-center gap-2 disabled:opacity-50"
                 >
                   <X class="w-4 h-4" />
                   취소
@@ -251,8 +315,8 @@ const deleteReview = (id: string) => {
           <h2 class="text-2xl font-bold">기업이 남긴 후기</h2>
         </div>
         <div class="space-y-4">
-          <div v-if="employerToFreelancerReviews.length === 0" class="text-center py-12 text-white/40">
-            아직 기업에서 남긴 후기가 없습니다.
+          <div v-if="!isLoading && employerToFreelancerReviews.length === 0" class="text-center py-12 text-white/40">
+            아직 기업이 남긴 후기가 없습니다.
           </div>
           <div
             v-for="(review, index) in employerToFreelancerReviews"

--- a/freebridgefe/src/views/freelancer/Review/ReviewWrite.vue
+++ b/freebridgefe/src/views/freelancer/Review/ReviewWrite.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed, reactive, ref } from 'vue';
-import { Star, ClipboardEdit, ArrowLeft } from 'lucide-vue-next';
-import { useAuthStore } from '@/stores/authStore';
+import { computed, onMounted, reactive, ref } from 'vue';
+import { Star, ClipboardEdit, ArrowLeft, LoaderCircle } from 'lucide-vue-next';
 import { useReviewStore } from '@/stores/reviewStore';
 
 const evaluationItems = [
@@ -11,17 +10,12 @@ const evaluationItems = [
 ] as const;
 
 type ReviewRatingKey = typeof evaluationItems[number]['key'];
-
 type ReviewFormRatings = Record<ReviewRatingKey, number>;
 
-const employerProjects = [
-  { id: 'p1', title: '대시보드 고도화', companyName: '프리브릿지' },
-  { id: 'p2', title: '브랜딩 UI 리뉴얼', companyName: '브랜드랩' },
-  { id: 'p3', title: '데이터 파이프라인 개선', companyName: '데이터메이트' },
-];
+const reviewStore = useReviewStore();
 
 const form = reactive({
-  projectId: '',
+  targetKey: '',
   ratings: {
     atmosphere: 0,
     requirementDetail: 0,
@@ -32,15 +26,22 @@ const form = reactive({
 
 const formError = ref('');
 const formSuccess = ref('');
-const authStore = useAuthStore();
-const reviewStore = useReviewStore();
 
-const selectedProject = computed(() => employerProjects.find((p) => p.id === form.projectId));
+const reviewTargets = computed(() => reviewStore.freelancerReviewTargets);
+const isLoadingTargets = computed(() => reviewStore.isFetchingReviewTargets);
+const targetFetchError = computed(() => reviewStore.reviewTargetFetchError);
+const isSubmitting = computed(() => reviewStore.isSubmittingReview);
+const selectedTarget = computed(() =>
+  reviewTargets.value.find((target) => target.key === form.targetKey),
+);
 
 const overallRating = computed(() => {
   const values = Object.values(form.ratings);
-  if (values.some((v) => v === 0)) return 0;
-  const sum = values.reduce((acc, v) => acc + v, 0);
+  if (values.some((value) => value === 0)) {
+    return 0;
+  }
+
+  const sum = values.reduce((acc, value) => acc + value, 0);
   return sum / values.length;
 });
 
@@ -49,7 +50,7 @@ const setRating = (field: ReviewRatingKey, value: number) => {
 };
 
 const resetForm = () => {
-  form.projectId = '';
+  form.targetKey = '';
   form.ratings = {
     atmosphere: 0,
     requirementDetail: 0,
@@ -58,16 +59,24 @@ const resetForm = () => {
   form.comment = '';
 };
 
-const handleSubmit = () => {
+const loadReviewTargets = async () => {
+  try {
+    await reviewStore.fetchFreelancerReviewTargets();
+  } catch {
+    formError.value = reviewStore.reviewTargetFetchError || '후기 작성 대상을 불러오지 못했습니다.';
+  }
+};
+
+const handleSubmit = async () => {
   formError.value = '';
   formSuccess.value = '';
 
-  if (!form.projectId) {
+  if (!selectedTarget.value) {
     formError.value = '프로젝트를 선택해 주세요.';
     return;
   }
 
-  if (Object.values(form.ratings).some((v) => v === 0)) {
+  if (Object.values(form.ratings).some((value) => value === 0)) {
     formError.value = '모든 평가 항목을 입력해 주세요.';
     return;
   }
@@ -81,25 +90,30 @@ const handleSubmit = () => {
     return;
   }
 
-  if (!selectedProject.value) {
-    formError.value = '프로젝트 정보를 찾을 수 없습니다.';
-    return;
+  try {
+    await reviewStore.addFreelancerToEmployerReview({
+      projectId: selectedTarget.value.projectId,
+      employerId: selectedTarget.value.counterpartyId,
+      freelancerId: '',
+      companyName: selectedTarget.value.counterpartyName,
+      projectName: selectedTarget.value.projectName,
+      atmosphere: form.ratings.atmosphere,
+      requirementDetail: form.ratings.requirementDetail,
+      schedule: form.ratings.schedule,
+      comment: form.comment.trim(),
+    });
+
+    formSuccess.value = '후기가 등록되었습니다.';
+    resetForm();
+  } catch (error) {
+    formError.value =
+      error instanceof Error ? error.message : '후기를 등록하지 못했습니다.';
   }
-
-  reviewStore.addFreelancerToEmployerReview({
-    freelancerId: authStore.user?.id,
-    freelancerName: authStore.user?.name || '프리랜서',
-    companyName: selectedProject.value.companyName,
-    projectName: selectedProject.value.title,
-    atmosphere: form.ratings.atmosphere,
-    requirementDetail: form.ratings.requirementDetail,
-    schedule: form.ratings.schedule,
-    comment: form.comment.trim(),
-  });
-
-  formSuccess.value = '후기가 등록되었습니다.';
-  resetForm();
 };
+
+onMounted(() => {
+  void loadReviewTargets();
+});
 </script>
 
 <template>
@@ -135,12 +149,15 @@ const handleSubmit = () => {
         <label class="flex flex-col gap-2">
           <span class="text-sm text-white/60">프로젝트 선택</span>
           <select
-            v-model="form.projectId"
-            class="bg-black/30 border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-white/30"
+            v-model="form.targetKey"
+            :disabled="isLoadingTargets || isSubmitting"
+            class="bg-black/30 border border-white/10 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-white/30 disabled:opacity-50"
           >
-            <option value="" disabled>프로젝트를 선택하세요</option>
-            <option v-for="project in employerProjects" :key="project.id" :value="project.id">
-              {{ project.title }} · {{ project.companyName }}
+            <option value="" disabled>
+              {{ isLoadingTargets ? '프로젝트를 불러오는 중...' : '프로젝트를 선택하세요' }}
+            </option>
+            <option v-for="target in reviewTargets" :key="target.key" :value="target.key">
+              {{ target.projectName }} · {{ target.counterpartyName }}
             </option>
           </select>
         </label>
@@ -148,9 +165,20 @@ const handleSubmit = () => {
         <div class="flex flex-col gap-2">
           <span class="text-sm text-white/60">선택된 기업</span>
           <div class="bg-black/20 border border-white/10 rounded-xl px-4 py-3 text-white/80">
-            {{ selectedProject?.companyName || '프로젝트를 선택해 주세요' }}
+            {{ selectedTarget?.counterpartyName || '프로젝트를 선택해 주세요' }}
           </div>
         </div>
+      </div>
+
+      <div v-if="isLoadingTargets" class="flex items-center gap-2 text-sm text-white/60 mb-6">
+        <LoaderCircle class="w-4 h-4 animate-spin" />
+        후기 작성 대상을 불러오는 중입니다.
+      </div>
+      <div v-else-if="targetFetchError" class="text-sm text-red-300 mb-6">
+        {{ targetFetchError }}
+      </div>
+      <div v-else-if="reviewTargets.length === 0" class="text-sm text-white/50 mb-6">
+        후기 작성 가능한 계약 프로젝트가 없습니다.
       </div>
 
       <div class="grid md:grid-cols-2 gap-6 mb-6">
@@ -168,7 +196,8 @@ const handleSubmit = () => {
               v-for="star in 5"
               :key="star"
               type="button"
-              class="transition-transform hover:scale-110"
+              class="transition-transform hover:scale-110 disabled:cursor-not-allowed"
+              :disabled="isSubmitting"
               @click="setRating(item.key, star)"
             >
               <Star
@@ -185,7 +214,8 @@ const handleSubmit = () => {
         <textarea
           v-model="form.comment"
           rows="4"
-          class="bg-black/30 border border-white/10 rounded-2xl px-4 py-3 text-white/90 focus:outline-none focus:ring-2 focus:ring-white/30"
+          :disabled="isSubmitting"
+          class="bg-black/30 border border-white/10 rounded-2xl px-4 py-3 text-white/90 focus:outline-none focus:ring-2 focus:ring-white/30 disabled:opacity-50"
           placeholder="프로젝트 진행 경험과 느낀 점을 작성해 주세요."
         ></textarea>
       </label>
@@ -196,15 +226,21 @@ const handleSubmit = () => {
         </div>
         <button
           type="button"
+          :disabled="isSubmitting || isLoadingTargets || reviewTargets.length === 0"
           @click="handleSubmit"
-          class="px-6 py-3 bg-white text-black rounded-full font-semibold hover:scale-105 transition-transform"
+          class="px-6 py-3 bg-white text-black rounded-full font-semibold hover:scale-105 transition-transform disabled:opacity-50 disabled:hover:scale-100"
         >
-          후기 등록
+          <span v-if="!isSubmitting">후기 등록</span>
+          <span v-else class="inline-flex items-center gap-2">
+            <LoaderCircle class="w-4 h-4 animate-spin" />
+            등록 중
+          </span>
         </button>
         <button
           type="button"
+          :disabled="isSubmitting"
           @click="resetForm"
-          class="px-6 py-3 bg-white/10 text-white rounded-full font-semibold hover:bg-white/20 transition-colors"
+          class="px-6 py-3 bg-white/10 text-white rounded-full font-semibold hover:bg-white/20 transition-colors disabled:opacity-50"
         >
           초기화
         </button>


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #이슈번호

## 📝 작업 내용
리뷰 기능을 mock 데이터 기반에서 실제 서버 API 연동 방식으로 전환하고,
프리랜서 리뷰 작성/조회 과정에서 발생하던 데이터 표시 문제를 함께 수정했습니다.

## ✅ Changes
- 리뷰/계약 API 클라이언트 추가 및 연동
- `reviewStore`를 서버 응답 기반 구조로 리팩터링
- 고용주/프리랜서 리뷰 작성 화면에 실제 작성 가능 프로젝트 목록 연결
- 고용주/프리랜서 리뷰 목록 화면에 조회, 수정, 삭제, 로딩/에러 처리 반영
- 프리랜서 리뷰 작성 시 선택한 프로젝트의 기업명이 `사용자 #N` 대신 실제 employer name으로 보이도록 보정
- 프리랜서 리뷰 목록 조회 시 일부 API 실패가 있어도 `내가 남긴 후기`가 비어 보이지 않도록 부분 성공 처리 적용
- 프론트 pull 충돌 발생 구간(`contractApi`, `MyApplications`) 정리 및 계약 API 경로 통합

## 📸 스크린샷 (선택)
리뷰 작성/목록 화면 변경 캡처 첨부 예정
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 계약 API는 백엔드 기준에 맞춰 `/api/v1/contracts` 경로로 정리했습니다.
- `contracts` 응답에 mock 이름이 내려오는 경우를 대비해 프론트에서 프로젝트 정보 기준으로 employer name을 보정합니다.
- 검증: `npm install`, `npm run build` 통과


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 서버 기반 프리랜서 검색 결과 및 페이지네이션 제공
  * 제안(프로포절) 생성/수신/수정/수락/거절 흐름 추가
  * 계약 관련 조회·생성·서명·완료 기능 개선

* **개선사항**
  * 전반적인 비동기 로딩·제출 상태 표시 및 에러 알림 강화
  * 리뷰 작성/목록 기능 확장(대상 조회, 작성·수정·삭제 비동기 처리)
  * 제안/리뷰 UI에서 제출 중 비활성화 및 사용자 피드백 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->