### PR TITLE
HFP-116 [feat] 구독 BE/FE 연결

### DIFF
--- a/freebridgefe/src/router/index.ts
+++ b/freebridgefe/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory, RouteRecordRaw } from 'vue-router'
 import { useAuthStore } from '@/stores/authStore'
 import { getEmployerProfile } from '@/api/MyPage/employer'
+import { getEmployerSubscription } from '@/api/MyPage/accountApi'
 
 const routes: Array<RouteRecordRaw> = [
     {
@@ -226,8 +227,8 @@ router.beforeEach(async (to, _from, next) => {
 
     if (to.name === 'employer.recommended' && authStore.user?.role === 'EMPLOYER') {
         try {
-            const profile = await getEmployerProfile()
-            const normalizedPlan = normalizeEmployerPlan(profile.plan)
+            const subscription = await getEmployerSubscription()
+            const normalizedPlan = normalizeEmployerPlan(subscription.currentPlan)
 
             if (!['PRO', 'PRIME'].includes(normalizedPlan)) {
                 alert('추천 프리랜서 기능은 프로 플랜 이상에서만 사용할 수 있습니다. 구독 레벨을 높여주세요.')

--- a/freebridgefe/src/views/employer/Recommended/RecommendedView.vue
+++ b/freebridgefe/src/views/employer/Recommended/RecommendedView.vue
@@ -49,6 +49,7 @@ const normalizePlan = (plan?: string): PlanType => {
 };
 
 const planLoading = ref(true);
+const planFetchError = ref<string | null>(null);
 
 const fetchCurrentPlan = async () => {
   planLoading.value = true;
@@ -57,7 +58,7 @@ const fetchCurrentPlan = async () => {
     currentPlan.value = normalizePlan(subscription.currentPlan);
   } catch (error) {
     console.error("Failed to fetch employer plan:", error);
-    currentPlan.value = "FREE";
+    planFetchError.value = "subscription_fetch_failed";
   } finally {
     planLoading.value = false;
   }

--- a/freebridgefe/src/views/employer/Recommended/RecommendedView.vue
+++ b/freebridgefe/src/views/employer/Recommended/RecommendedView.vue
@@ -4,7 +4,7 @@ import { TrendingUp, Send, Star } from "lucide-vue-next";
 import { useFreelancerStore } from "@/stores/freelancerStore";
 import { useFavoritesStore } from "@/stores/favoritesStore";
 import { useJobStore } from "@/stores/jobStore";
-import { getEmployerProfile } from "@/api/MyPage/employer";
+import { getEmployerSubscription } from "@/api/MyPage/accountApi";
 import ProposalModal from "./components/ProposalModal.vue";
 import type { User } from "@/types";
 
@@ -53,8 +53,8 @@ const planLoading = ref(true);
 const fetchCurrentPlan = async () => {
   planLoading.value = true;
   try {
-    const profile = await getEmployerProfile();
-    currentPlan.value = normalizePlan(profile.plan);
+    const subscription = await getEmployerSubscription();
+    currentPlan.value = normalizePlan(subscription.currentPlan);
   } catch (error) {
     console.error("Failed to fetch employer plan:", error);
     currentPlan.value = "FREE";


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #96 

## 📝 작업 내용
추천 프리랜서 접근 권한 체크를 구독 API 기반으로 통일하고, PRO/PRIME 플랜에서 정상 접근되도록 개선

## ✅ Changes
- 추천 프리랜서 화면에서 currentPlan을 구독 API(`getEmployerSubscription`) 응답으로 계산
- 라우터 가드에서도 subscription.currentPlan 기반으로 접근 권한 검증

## 📸 스크린샷 (선택)
### `pro` 플랜 이상일 경우 추천프리랜서 페이지에 접근 가능
<img width="1634" height="510" alt="image" src="https://github.com/user-attachments/assets/064343a0-cdb9-44b4-bc6e-d6ecc41a1788" />


## ⚠️ Notes (Optional)
> 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 고용주 추천 흐름에서 구독 정보 기반 처리가 도입되어 관련 동작의 안정성이 향상되었습니다.
  * PRO/PRIME 플랜 검증 로직은 기존 방식대로 유지됩니다.
  * 구독 정보 조회 실패 시 명확한 오류 상태가 기록되며, 실패 처리의 일관성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->