### PR TITLE
 HFP-110 [fix] 빈 FRONTEND_API_BASE_URL을 직접 참조하던 부분이 비어도 문제가 없게 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
 
                             export DOCKER_BUILDKIT=0
                             docker build \
-                              --build-arg VITE_API_BASE_URL="${FRONTEND_API_BASE_URL}" \
+                              --build-arg VITE_API_BASE_URL="${FRONTEND_API_BASE_URL:-}" \
                               -t ${IMAGE_NAME}:${IMAGE_TAG} .
 
                             echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Docker 빌드 설정에서 API 기본 URL 처리 방식을 개선하여, 환경 변수가 미설정 시 빈 문자열을 기본값으로 사용하도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->