### PR TITLE
HFP-109 fix: 제안 모달에서 중복 제안 공고를 제외하고 에러 메시지 개선

### DIFF
--- a/freebridgefe/src/stores/freelancerStore.ts
+++ b/freebridgefe/src/stores/freelancerStore.ts
@@ -30,10 +30,17 @@ const getProposalErrorMessage = (error: unknown): string => {
   if (
     typeof error === "object" &&
     error !== null &&
-    "response" in error &&
-    typeof (error as any).response?.data?.message === "string"
+    "response" in error
   ) {
-    return (error as any).response.data.message;
+    const responseErrorMessage = (error as any).response?.data?.error?.message;
+    if (typeof responseErrorMessage === "string" && responseErrorMessage.trim()) {
+      return responseErrorMessage;
+    }
+
+    const responseMessage = (error as any).response?.data?.message;
+    if (typeof responseMessage === "string" && responseMessage.trim()) {
+      return responseMessage;
+    }
   }
 
   if (error instanceof Error && error.message) {

--- a/freebridgefe/src/views/employer/Recommended/components/ProposalModal.vue
+++ b/freebridgefe/src/views/employer/Recommended/components/ProposalModal.vue
@@ -25,14 +25,39 @@ const isSubmitting = ref(false);
 
 onMounted(async () => {
   try {
-    await jobStore.fetchJobPostings();
+    await Promise.all([
+      jobStore.fetchJobPostings(),
+      freelancerStore.fetchEmployerProposals().catch((error) => {
+        console.warn('Failed to load existing employer proposals for proposal modal:', error);
+      }),
+    ]);
   } catch (error) {
     console.error('Failed to load employer jobs for proposal modal:', error);
     window.alert('공고 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.');
   }
 });
 
-const employerJobs = computed(() => jobStore.myJobs.filter((job) => job.status === 'OPEN'));
+const proposedJobIdsForFreelancer = computed(() => {
+  const freelancerId = String(props.freelancer.id);
+  const employerId = String(authStore.user?.id ?? '');
+
+  return new Set(
+    freelancerStore.proposals
+      .filter(
+        (proposal) =>
+          proposal.freelancerId === freelancerId &&
+          proposal.employerId === employerId &&
+          proposal.jobId,
+      )
+      .map((proposal) => proposal.jobId as string),
+  );
+});
+
+const openEmployerJobs = computed(() => jobStore.myJobs.filter((job) => job.status === 'OPEN'));
+
+const employerJobs = computed(() =>
+  openEmployerJobs.value.filter((job) => !proposedJobIdsForFreelancer.value.has(job.id))
+);
 
 watch(
   employerJobs,
@@ -84,7 +109,12 @@ const handleSubmit = async () => {
     emit('close');
   } catch (error: any) {
     console.error('Failed to send proposal:', error);
-    alert(error?.response?.data?.message || error?.message || '제안 전송에 실패했습니다.');
+    alert(
+      error?.response?.data?.error?.message ||
+      error?.response?.data?.message ||
+      error?.message ||
+      '제안 전송에 실패했습니다.'
+    );
   } finally {
     isSubmitting.value = false;
   }
@@ -149,7 +179,11 @@ const handleSubmit = async () => {
             </option>
           </select>
           <p v-if="employerJobs.length === 0" class="mt-2 text-sm text-amber-300">
-            제안 가능한 모집중 프로젝트가 없습니다. 먼저 공고를 등록하거나 상태를 확인해주세요.
+            {{
+              openEmployerJobs.length === 0
+                ? '제안 가능한 모집중 프로젝트가 없습니다. 먼저 공고를 등록하거나 상태를 확인해주세요.'
+                : '이 프리랜서에게 이미 제안한 공고만 남아 있습니다.'
+            }}
           </p>
         </div>
 


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
고용주 제안 모달에서 이미 같은 프리랜서에게 제안한 공고를 다시 선택하지 못하도록 프론트 로직을 보완하고, 제안 실패 시 실제 서버 에러 메시지가 사용자에게 보이도록 수정했습니다.

## ✅ Changes
- 제안 모달 진입 시 고용주의 기존 제안 목록을 함께 조회하도록 변경
- 이미 해당 프리랜서에게 제안한 공고는 제안 모달의 공고 선택 목록에서 제외
- 선택 가능한 모집중 공고가 없는 경우 상황에 맞는 안내 문구 노출
- 제안 실패 시 API 응답의 `error.message`를 우선적으로 읽도록 에러 메시지 처리 개선
- 프론트 빌드로 변경 사항 검증 (`npm run build`)

## 📸 스크린샷 (선택)
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 이번 PR은 백엔드의 중복 제안 차단 정책에 맞춰 프론트에서 사전 방지와 메시지 표시를 보완한 내용입니다.
- 기존 제안 목록 조회가 실패해도 모달 사용은 가능하도록 처리했고, 이 경우에는 서버에서 최종 검증합니다.