### PR TITLE
HFP-110 [fix] ID가 e1/f1와 raw 숫자 형태로 섞여도 같은 사람으로 인식하도록 공통 정규화

### DIFF
--- a/freebridgefe/src/components/chat/ChatInfoPanel.vue
+++ b/freebridgefe/src/components/chat/ChatInfoPanel.vue
@@ -9,7 +9,7 @@
             </div>
             
             <h2 class="text-xl font-bold text-white mb-1">{{ otherParticipantName }}</h2>
-            <p class="text-sm text-slate-400 mb-4">시니어 프론트엔드 개발자</p>
+            <p class="text-sm text-slate-400 mb-4">{{ otherParticipantSummary }}</p>
             
             <div class="flex gap-2 w-full">
                 <button
@@ -172,8 +172,7 @@ import { useFreelancerStore } from '@/stores/freelancerStore';
 import { getEmployerProfile } from '@/api/MyPage/employer';
 import { 
     Code as CodeIcon,
-    FileText as FileTextIcon,
-    Image as ImageIcon
+    FileText as FileTextIcon
 } from 'lucide-vue-next';
 
 const props = defineProps<{
@@ -216,9 +215,51 @@ const sharedFiles = computed(() => {
 const currentRoom = computed(() => chatStore.rooms.find(r => r.id === props.roomId));
 
 const otherParticipantName = computed(() => {
-    if (!currentRoom.value || !authStore.user) return 'Unknown';
-    const otherId = chatStore.getOtherParticipantId(currentRoom.value);
-    return otherId ? (currentRoom.value.participantNames[otherId] || '알 수 없음') : '알 수 없음';
+    if (!currentRoom.value) return '알 수 없음';
+    return chatStore.getOtherParticipantName(currentRoom.value);
+});
+
+const otherParticipantSummary = computed(() => {
+    const room = currentRoom.value;
+    if (!room || !authStore.user) {
+        return '상대 정보를 불러오는 중입니다.';
+    }
+
+    const otherId = chatStore.getOtherParticipantId(room);
+    const otherUserId = otherId?.replace(/^[a-z]/i, '') ?? '';
+    const proposal = room.relatedProposalId
+        ? freelancerStore.proposals.find((item) => item.id === room.relatedProposalId)
+        : null;
+    const job = room.relatedJobId ? jobStore.getJobById(room.relatedJobId) : null;
+
+    if (authStore.user.role === 'EMPLOYER') {
+        const freelancer = freelancerStore.freelancers.find(
+            (item) => String(item.id) === otherUserId
+        );
+        const introduction = freelancer?.bio?.trim();
+        if (introduction) {
+            return introduction;
+        }
+
+        const skills = freelancer?.skills?.filter(Boolean).slice(0, 3) ?? [];
+        if (skills.length > 0) {
+            return `주요 기술: ${skills.join(', ')}`;
+        }
+
+        return '프리랜서 소개 정보가 아직 없습니다.';
+    }
+
+    const companyDescription = job?.description?.trim();
+    if (companyDescription) {
+        return companyDescription;
+    }
+
+    const proposalMessage = proposal?.message?.trim();
+    if (proposalMessage) {
+        return proposalMessage;
+    }
+
+    return '기업 소개 정보가 아직 없습니다.';
 });
 
 const proposedProject = computed(() => {
@@ -253,9 +294,10 @@ const handleProfileClick = () => {
 
     const otherId = chatStore.getOtherParticipantId(room);
     if (!otherId) return;
+    const otherUserId = otherId.replace(/^[a-z]/i, '');
 
     if (authStore.user.role === 'EMPLOYER') {
-        router.push({ name: 'employer.freelancer.profile', params: { id: otherId } });
+        router.push({ name: 'employer.freelancer.profile', params: { id: otherUserId } });
         return;
     }
 
@@ -265,7 +307,7 @@ const handleProfileClick = () => {
         : null;
 
     employerProfile.value = {
-        companyName: job?.employerName || proposal?.employerName || room.participantNames[otherId] || '알 수 없음',
+        companyName: job?.employerName || proposal?.employerName || chatStore.getParticipantName(room, otherId) || '알 수 없음',
         phone: job ? '02-0000-0000' : '02-0000-0000',
         location: job ? '서울' : '서울'
     };
@@ -275,7 +317,7 @@ const handleProfileClick = () => {
         return;
     }
 
-    getEmployerProfile(otherId)
+    getEmployerProfile(otherUserId)
         .then((profile) => {
             employerProfile.value = {
                 companyName: profile.companyName || employerProfile.value.companyName,

--- a/freebridgefe/src/components/chat/ChatMessageContract.vue
+++ b/freebridgefe/src/components/chat/ChatMessageContract.vue
@@ -1,84 +1,57 @@
 <template>
     <div class="w-72 bg-slate-800 rounded-xl border border-emerald-500/30 overflow-hidden shadow-md my-2">
-        <!-- Header -->
         <div class="px-4 py-3 bg-slate-800/50 border-b border-white/5 flex items-center gap-3">
             <div class="w-8 h-8 rounded-lg bg-emerald-500/10 flex items-center justify-center">
                 <FileTextIcon class="w-4 h-4 text-emerald-500" />
             </div>
             <div>
-                <p class="text-xs font-semibold text-emerald-400 uppercase tracking-wider">계약 요청</p>
+                <p class="text-xs font-semibold text-emerald-400 uppercase tracking-wider">계약 알림</p>
                 <p class="text-sm font-bold text-white">{{ contractTitle }}</p>
             </div>
         </div>
 
-        <!-- Content -->
         <div class="p-4 space-y-3">
-            <div class="flex justify-between items-center text-sm">
+            <div class="flex justify-between items-center text-sm gap-3">
                 <span class="text-slate-400">상태</span>
                 <span :class="statusBadgeClass">
                     {{ statusLabel }}
                 </span>
             </div>
-            
+
             <div class="space-y-1">
                 <p class="text-xs text-slate-500">프로젝트명</p>
                 <p class="text-sm text-slate-300 font-medium truncate">{{ contractProjectName }}</p>
             </div>
-            <div v-if="contractProjectId" class="text-xs text-slate-500">
-                프로젝트 ID · {{ contractProjectId }}
+
+            <div v-if="contractNumberLabel" class="text-xs text-slate-500">
+                계약번호 · {{ contractNumberLabel }}
             </div>
 
-            <div class="pt-2 flex gap-2">
-                <button
-                    class="flex-1 py-2 text-xs font-medium text-slate-300 bg-slate-700 hover:bg-slate-600 rounded-lg transition-colors border border-white/5"
-                    @click="openDetailModal"
-                    :disabled="!contractDetails"
-                >
-                    상세 보기
-                </button>
-                <button
-                    v-if="showSignButton"
-                    class="flex-1 py-2 text-xs font-medium text-white bg-emerald-600 hover:bg-emerald-500 rounded-lg transition-colors shadow-lg shadow-emerald-900/20"
-                    @click="openSignatureModal"
-                >
-                    서명하기
-                </button>
-                <button
-                    v-if="showRejectButton"
-                    class="flex-1 py-2 text-xs font-medium text-rose-200 bg-rose-500/30 hover:bg-rose-500/40 rounded-lg transition-colors shadow-lg shadow-rose-900/20"
-                    @click="rejectContract"
-                >
-                    거절하기
-                </button>
+            <div v-if="isLoadingContract" class="text-xs text-slate-500">
+                계약 정보를 불러오는 중입니다.
             </div>
+
+            <p class="text-xs text-slate-400 leading-relaxed">
+                채팅에서는 계약 조작을 하지 않습니다. 상세 확인과 서명은 계약 화면에서 진행하세요.
+            </p>
+
+            <button
+                class="w-full py-2 text-xs font-medium text-white bg-emerald-600 hover:bg-emerald-500 rounded-lg transition-colors shadow-lg shadow-emerald-900/20"
+                @click="openContractPage"
+            >
+                계약 화면으로 이동
+            </button>
         </div>
     </div>
-
-    <ContractDetailModal
-        v-if="isDetailOpen && contractDetails"
-        :contract="contractDetails"
-        :isFreelancer="!isEmployer"
-        @close="isDetailOpen = false"
-        @sign="openSignatureModal"
-    />
-
-    <SignaturePadModal
-        v-if="isSignatureOpen && authStore.user"
-        :signerName="authStore.user.name"
-        @sign="handleSignature"
-        @close="isSignatureOpen = false"
-    />
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, onMounted } from 'vue';
+import { useRouter } from 'vue-router';
 import { FileText as FileTextIcon } from 'lucide-vue-next';
 import type { ChatMessage } from '@/types';
 import { useAuthStore } from '@/stores/authStore';
 import { useContractStore } from '@/stores/contractStore';
-import { useChatStore } from '@/stores/chatStore';
-import ContractDetailModal from '@/views/employer/Contracts/components/ContractDetailModal.vue';
-import SignaturePadModal from '@/views/employer/Contracts/components/SignaturePadModal.vue';
 
 const props = defineProps<{
     message?: ChatMessage;
@@ -86,110 +59,81 @@ const props = defineProps<{
 
 const authStore = useAuthStore();
 const contractStore = useContractStore();
-const chatStore = useChatStore();
-const isDetailOpen = ref(false);
-const isSignatureOpen = ref(false);
+const router = useRouter();
 
-const contractId = computed(() => {
+const contractIdentifier = computed(() => {
     const raw = props.message?.metadata?.contractId;
     const parsed = Number(raw);
-    return Number.isNaN(parsed) ? null : parsed;
+    return Number.isFinite(parsed) ? parsed : null;
 });
 
 const contractDetails = computed(() => {
-    if (!contractId.value) return null;
-    return contractStore.contractsWithDetails.find((c) => c.id === contractId.value) || null;
+    if (!contractIdentifier.value) return null;
+    return contractStore.findContractByAnyId(contractIdentifier.value);
 });
 
 const isEmployer = computed(() => authStore.user?.role === 'EMPLOYER');
-const contractTitle = computed(() => contractDetails.value?.projectName || '프로젝트 표준 계약');
-const contractProjectName = computed(() => contractDetails.value?.projectName || '계약 정보 없음');
-const contractProjectId = computed(() => contractDetails.value?.projectId || '');
+const isLoadingContract = computed(() => contractStore.isContractsLoading && !contractDetails.value);
+const contractTitle = computed(() => contractDetails.value?.projectName || '계약 상태 알림');
+const contractProjectName = computed(() => contractDetails.value?.projectName || props.message?.content || '계약 정보 확인 필요');
+const contractNumberLabel = computed(() => {
+    if (contractDetails.value?.contractId) return String(contractDetails.value.contractId);
+    if (contractIdentifier.value) return String(contractIdentifier.value);
+    return '';
+});
+
+const resolvedStatus = computed(() => contractDetails.value?.status || props.message?.metadata?.status || '');
 
 const statusLabel = computed(() => {
-    const status = contractDetails.value?.status;
-    if (!status) return '정보 없음';
-    if (status === 'WAITING_SIGNATURE') return '서명 대기중';
-    if (status === 'IN_PROGRESS') return '진행 중';
-    if (status === 'COMPLETED') return '완료';
-    if (status === 'REJECTED') return '거절됨';
-    return status;
+    if (resolvedStatus.value === 'WAITING_SIGNATURE') return '서명 대기중';
+    if (resolvedStatus.value === 'IN_PROGRESS') return '진행 중';
+    if (resolvedStatus.value === 'COMPLETED') return '완료';
+    if (resolvedStatus.value === 'REJECTED') return '거절됨';
+    if (isLoadingContract.value) return '조회 중';
+    return '확인 필요';
 });
 
 const statusBadgeClass = computed(() => {
-    const status = contractDetails.value?.status;
-    if (status === 'WAITING_SIGNATURE') {
+    if (resolvedStatus.value === 'WAITING_SIGNATURE') {
         return 'px-2 py-0.5 rounded text-xs font-medium bg-yellow-500/10 text-yellow-500 border border-yellow-500/20';
     }
-    if (status === 'IN_PROGRESS') {
+    if (resolvedStatus.value === 'IN_PROGRESS') {
         return 'px-2 py-0.5 rounded text-xs font-medium bg-blue-500/10 text-blue-400 border border-blue-500/20';
     }
-    if (status === 'COMPLETED') {
+    if (resolvedStatus.value === 'COMPLETED') {
         return 'px-2 py-0.5 rounded text-xs font-medium bg-emerald-500/10 text-emerald-400 border border-emerald-500/20';
     }
-    if (status === 'REJECTED') {
+    if (resolvedStatus.value === 'REJECTED') {
         return 'px-2 py-0.5 rounded text-xs font-medium bg-rose-500/10 text-rose-400 border border-rose-500/20';
     }
     return 'px-2 py-0.5 rounded text-xs font-medium bg-slate-500/10 text-slate-400 border border-slate-500/20';
 });
 
-const showSignButton = computed(() => {
-    if (!contractDetails.value || !authStore.user) return false;
-    if (contractDetails.value.status !== 'WAITING_SIGNATURE') return false;
-    return isEmployer.value
-        ? !contractDetails.value.employerSignedDate
-        : !contractDetails.value.freelancerSignedDate;
-});
-
-const showRejectButton = computed(() => {
-    if (!contractDetails.value || !authStore.user) return false;
-    if (contractDetails.value.status !== 'WAITING_SIGNATURE') return false;
-    return !isEmployer.value && !contractDetails.value.freelancerSignedDate;
-});
-
-function openDetailModal() {
-    if (!contractDetails.value) return;
-    isDetailOpen.value = true;
-}
-
-function openSignatureModal() {
-    if (!contractDetails.value) return;
-    isSignatureOpen.value = true;
-}
-
-function handleSignature(signatureDataUrl: string) {
-    if (!contractDetails.value || !authStore.user) return;
-
-    const updates: Record<string, any> = {};
-    if (isEmployer.value) {
-        updates.employerSignature = signatureDataUrl;
-        updates.employerSignedDate = new Date();
-    } else {
-        updates.freelancerSignature = signatureDataUrl;
-        updates.freelancerSignedDate = new Date();
-    }
-
-    const nextEmployerSigned = updates.employerSignedDate || contractDetails.value.employerSignedDate;
-    const nextFreelancerSigned = updates.freelancerSignedDate || contractDetails.value.freelancerSignedDate;
-
-    if (nextEmployerSigned && nextFreelancerSigned) {
-        updates.status = 'IN_PROGRESS';
-        updates.signedDate = new Date();
-        if (props.message?.roomId) {
-            chatStore.sendSystemMessage(props.message.roomId, '계약서 서명이 완료되었습니다.');
-        }
-    }
-
-    contractStore.updateContract(contractDetails.value.id, updates);
-    isSignatureOpen.value = false;
-}
-
-function rejectContract() {
-    if (!contractDetails.value) return;
-    if (!confirm('계약을 거절하시겠습니까?')) return;
-    contractStore.updateContract(contractDetails.value.id, { status: 'REJECTED' });
+function openContractPage() {
+    const query: Record<string, string> = {};
     if (props.message?.roomId) {
-        chatStore.sendSystemMessage(props.message.roomId, '계약이 거절되었습니다.');
+        query.roomId = props.message.roomId;
     }
+    if (contractDetails.value?.contractId) {
+        query.contractId = String(contractDetails.value.contractId);
+    } else if (contractIdentifier.value) {
+        query.contractId = String(contractIdentifier.value);
+    }
+
+    router.push({
+        name: isEmployer.value ? 'employer.contracts' : 'freelancer.contracts',
+        query,
+    });
 }
+
+onMounted(() => {
+    if (contractStore.isContractsLoading) return;
+    const loadContracts = contractIdentifier.value && !contractDetails.value
+        ? contractStore.fetchContracts()
+        : contractStore.ensureContractsLoaded();
+
+    void loadContracts.catch((error) => {
+        console.error('Failed to load contracts for contract alert:', error);
+    });
+});
 </script>

--- a/freebridgefe/src/components/chat/ChatSidebar.vue
+++ b/freebridgefe/src/components/chat/ChatSidebar.vue
@@ -289,6 +289,11 @@ function handleGlobalKeydown(event: KeyboardEvent) {
 }
 
 onMounted(() => {
+    if (authStore.isAuthenticated) {
+        chatStore.fetchRooms().catch((error) => {
+            console.error('Failed to refresh chat rooms on sidebar mount:', error);
+        });
+    }
     pinnedRoomIds.value = readStoredRoomIds(CHAT_PINNED_ROOMS_KEY);
     mutedRoomIds.value = readStoredRoomIds(CHAT_MUTED_ROOMS_KEY);
     hiddenRoomIds.value = readStoredRoomIds(CHAT_HIDDEN_ROOMS_KEY);
@@ -307,9 +312,7 @@ function getOtherParticipantImage(room: ChatRoom) {
 }
 
 function getOtherParticipantName(room: ChatRoom) {
-    if (!authStore.user) return 'Unknown';
-    const otherId = chatStore.getOtherParticipantId(room);
-    return otherId && room.participantNames[otherId] ? room.participantNames[otherId] : '알 수 없음';
+    return chatStore.getOtherParticipantName(room);
 }
 
 function getMyUnreadCount(room: ChatRoom) {

--- a/freebridgefe/src/components/chat/ChatWindow.vue
+++ b/freebridgefe/src/components/chat/ChatWindow.vue
@@ -132,7 +132,6 @@ import ContractTab from './ContractTab.vue';
 import { 
     FileText as FileTextIcon,
     LogOut as LogOutIcon,
-    Paperclip as PaperclipIcon,
     Send as SendIcon,
     Plus as PlusIcon
 } from 'lucide-vue-next';
@@ -154,22 +153,70 @@ const currentRoom = computed(() => chatStore.rooms.find(r => r.id === props.room
 const messages = computed(() => chatStore.messages[props.roomId] || []);
 const nonSystemMessages = computed(() => messages.value.filter((msg) => msg.type !== 'SYSTEM'));
 const isReadOnly = computed(() => chatStore.isRoomReadOnly(props.roomId));
+const otherParticipantId = computed(() => {
+    if (!currentRoom.value) return null;
+    return chatStore.getOtherParticipantId(currentRoom.value) || null;
+});
 
 const otherParticipantName = computed(() => {
     if (!currentRoom.value) return '알 수 없음';
     return chatStore.getOtherParticipantName(currentRoom.value);
 });
 
+function parseParticipantNumericId(participantId: string | null) {
+    if (!participantId) return null;
+    const matchedParticipant = String(participantId).match(/^[efa](\d+)$/i);
+    if (matchedParticipant) {
+        return Number(matchedParticipant[1]);
+    }
+    const numericId = Number(participantId);
+    return Number.isFinite(numericId) ? numericId : null;
+}
+
+const roomContract = computed(() => {
+    const linkedContract = contractStore.findContractByAnyId(currentRoom.value?.contractId);
+    if (linkedContract) return linkedContract;
+    if (!authStore.user || !otherParticipantId.value) return null;
+
+    const myUserId = Number(authStore.user.id);
+    const counterpartId = parseParticipantNumericId(otherParticipantId.value);
+    if (!Number.isFinite(myUserId) || !Number.isFinite(counterpartId)) return null;
+
+    const employerId = authStore.user.role === 'EMPLOYER' ? myUserId : counterpartId;
+    const freelancerId = authStore.user.role === 'FREELANCER' ? myUserId : counterpartId;
+
+    return contractStore.findContractByParticipants(employerId, freelancerId);
+});
+
 const contractNeedsAttention = computed(() => {
-    if (!currentRoom.value || !authStore.user) return false;
-    const contractId = currentRoom.value.contractId;
-    if (!contractId) return false;
-    const contract = contractStore.contracts.find((c) => c.id === contractId);
+    if (!authStore.user) return false;
+    const contract = roomContract.value;
     if (!contract || contract.status !== 'WAITING_SIGNATURE') return false;
     if (authStore.user.role === 'EMPLOYER') {
         return !contract.employerSignedDate;
     }
     return !contract.freelancerSignedDate;
+});
+
+const shouldLoadContracts = computed(() => {
+    if (!currentRoom.value) return false;
+    if (activeTab.value === 'CONTRACT') return true;
+    if (currentRoom.value.contractId) return true;
+    return messages.value.some((message) => message.type === 'CONTRACT_ALERT');
+});
+
+const shouldRefreshContracts = computed(() => {
+    if (!shouldLoadContracts.value) return false;
+    if (!contractStore.hasFetchedContracts) return true;
+    if (currentRoom.value?.contractId && !contractStore.findContractByAnyId(currentRoom.value.contractId)) {
+        return true;
+    }
+
+    return messages.value.some((message) => {
+        if (message.type !== 'CONTRACT_ALERT') return false;
+        const contractId = message.metadata?.contractId;
+        return !!contractId && !contractStore.findContractByAnyId(contractId);
+    });
 });
 
 function handleLeaveRoom() {
@@ -217,9 +264,29 @@ function scrollToBottom() {
     });
 }
 
+async function ensureContractsLoadedForChat() {
+    if (!shouldLoadContracts.value) return;
+    try {
+        if (shouldRefreshContracts.value) {
+            await contractStore.fetchContracts();
+            return;
+        }
+        await contractStore.ensureContractsLoaded();
+    } catch (error) {
+        console.error('Failed to load contracts for chat:', error);
+    }
+}
+
 // Scroll to bottom on mount and when messages change
-onMounted(scrollToBottom);
+onMounted(() => {
+    scrollToBottom();
+    void ensureContractsLoadedForChat();
+});
 watch(messages, scrollToBottom, { deep: true });
+watch(shouldLoadContracts, (nextShouldLoadContracts) => {
+    if (!nextShouldLoadContracts) return;
+    void ensureContractsLoadedForChat();
+}, { immediate: true });
 
 watch(
     () => props.roomId,

--- a/freebridgefe/src/components/chat/ChatWindow.vue
+++ b/freebridgefe/src/components/chat/ChatWindow.vue
@@ -264,11 +264,19 @@ function scrollToBottom() {
     });
 }
 
+async function fetchContractsForChat() {
+    try {
+        await contractStore.fetchContracts();
+    } catch (error) {
+        console.error('Failed to refresh contracts for chat:', error);
+    }
+}
+
 async function ensureContractsLoadedForChat() {
     if (!shouldLoadContracts.value) return;
     try {
         if (shouldRefreshContracts.value) {
-            await contractStore.fetchContracts();
+            await fetchContractsForChat();
             return;
         }
         await contractStore.ensureContractsLoaded();
@@ -283,9 +291,9 @@ onMounted(() => {
     void ensureContractsLoadedForChat();
 });
 watch(messages, scrollToBottom, { deep: true });
-watch(shouldLoadContracts, (nextShouldLoadContracts) => {
-    if (!nextShouldLoadContracts) return;
-    void ensureContractsLoadedForChat();
+watch(shouldRefreshContracts, (nextShouldRefreshContracts) => {
+    if (!nextShouldRefreshContracts) return;
+    void fetchContractsForChat();
 }, { immediate: true });
 
 watch(

--- a/freebridgefe/src/components/chat/ChatWindow.vue
+++ b/freebridgefe/src/components/chat/ChatWindow.vue
@@ -156,9 +156,8 @@ const nonSystemMessages = computed(() => messages.value.filter((msg) => msg.type
 const isReadOnly = computed(() => chatStore.isRoomReadOnly(props.roomId));
 
 const otherParticipantName = computed(() => {
-    if (!currentRoom.value || !authStore.user) return 'Unknown';
-    const otherId = chatStore.getOtherParticipantId(currentRoom.value);
-    return otherId ? (currentRoom.value.participantNames[otherId] || '알 수 없음') : '알 수 없음';
+    if (!currentRoom.value) return '알 수 없음';
+    return chatStore.getOtherParticipantName(currentRoom.value);
 });
 
 const contractNeedsAttention = computed(() => {
@@ -182,7 +181,8 @@ function handleLeaveRoom() {
 
 function getSenderName(senderId: string) {
     if (senderId === 'SYSTEM') return 'System';
-    return currentRoom.value?.participantNames[senderId] || 'Unknown';
+    if (!currentRoom.value) return '알 수 없음';
+    return chatStore.getParticipantName(currentRoom.value, senderId) || '알 수 없음';
 }
 
 function sendMessage() {

--- a/freebridgefe/src/components/chat/ContractTab.vue
+++ b/freebridgefe/src/components/chat/ContractTab.vue
@@ -1,318 +1,153 @@
 <template>
     <div class="h-full flex flex-col bg-slate-950 overflow-y-auto custom-scrollbar">
-        <!-- Header -->
         <div class="p-6 bg-slate-900 border-b border-white/5 sticky top-0 z-10">
             <h2 class="text-xl font-bold text-white">계약 관리</h2>
-            <p class="text-sm text-slate-400 mt-1">프로젝트 계약 진행 상황을 확인하세요.</p>
+            <p class="text-sm text-slate-400 mt-1">
+                채팅에서는 계약 상태만 확인하고, 실제 작성과 서명은 계약 화면에서 진행합니다.
+            </p>
         </div>
 
         <div class="p-6 flex-1">
-            <!-- Case 1: No Contract -->
+            <div
+                v-if="isContractLookupPending"
+                class="h-full min-h-[320px] flex flex-col items-center justify-center text-center space-y-4"
+            >
+                <div class="w-16 h-16 rounded-2xl bg-slate-900 border border-white/5 flex items-center justify-center">
+                    <Loader2Icon class="w-8 h-8 text-emerald-400 animate-spin" />
+                </div>
+                <div>
+                    <h3 class="text-lg font-bold text-white">계약 정보를 불러오는 중입니다</h3>
+                    <p class="text-sm text-slate-400 mt-2">잠시 후 현재 대화와 연결된 계약 상태를 확인합니다.</p>
+                </div>
+            </div>
 
-            <div v-if="!currentContract" class="flex flex-col items-center justify-center h-full text-center space-y-4">
-                <div class="w-20 h-20 rounded-2xl bg-slate-800/50 flex items-center justify-center mb-2">
+            <div
+                v-else-if="!currentContract"
+                class="h-full min-h-[320px] flex flex-col items-center justify-center text-center space-y-4"
+            >
+                <div class="w-20 h-20 rounded-2xl bg-slate-900 border border-white/5 flex items-center justify-center">
                     <FileTextIcon class="w-10 h-10 text-slate-600" />
                 </div>
-                <h3 class="text-lg font-bold text-white">진행 중인 계약이 없습니다</h3>
-                <p class="text-sm text-slate-400 max-w-xs leading-relaxed">
-                    프로젝트 진행을 위해 계약서를 작성해주세요.<br>
-                    계약서가 작성되면 이곳에서 서명을 진행할 수 있습니다.
-                </p>
-                <button 
-                    v-if="isEmployer"
-                    @click="initiateContract"
-                    class="mt-4 px-6 py-2.5 bg-emerald-600 text-white text-sm font-bold rounded-lg hover:bg-emerald-500 transition-all shadow-lg shadow-emerald-900/20"
+                <div class="space-y-2">
+                    <h3 class="text-lg font-bold text-white">
+                        {{ hasMultipleContractCandidates ? '계약이 여러 건 있어 자동 연결하지 않았습니다' : '연결된 계약이 없습니다' }}
+                    </h3>
+                    <p class="text-sm text-slate-400 max-w-md leading-relaxed">
+                        {{ emptyStateDescription }}
+                    </p>
+                </div>
+                <button
+                    @click="openContractPage"
+                    class="mt-2 inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-emerald-600 text-white font-semibold hover:bg-emerald-500 transition-colors shadow-lg shadow-emerald-950/30"
                 >
-                    계약서 작성하기
-                </button>
-                <button 
-                    v-else
-                    @click="requestContract"
-                    class="mt-4 px-6 py-2.5 bg-slate-800 border border-white/10 text-slate-300 text-sm font-medium rounded-lg hover:bg-slate-700 hover:text-white transition-colors"
-                >
-                    계약서 요청하기
+                    {{ primaryActionLabel }}
+                    <ArrowRightIcon class="w-4 h-4" />
                 </button>
             </div>
 
-            <!-- Case 2: Contract Draft / Waiting Signature -->
-            <div v-else-if="currentContract.status === 'WAITING_SIGNATURE'" class="bg-slate-900 rounded-xl shadow-lg border border-white/5 overflow-hidden">
-                <div class="bg-yellow-500/10 px-6 py-4 border-b border-yellow-500/20 flex items-center gap-3">
-                    <ClockIcon class="w-5 h-5 text-yellow-500" />
-                    <span class="font-bold text-yellow-500">계약 서명 대기중</span>
-                </div>
-                
-                <div class="p-6 space-y-6">
-                    <div>
-                        <h4 class="text-xs font-semibold text-slate-500 mb-1 uppercase tracking-wider">프로젝트명</h4>
-                        <p class="text-lg font-bold text-white">{{ currentContract.projectName }}</p>
-                        <p v-if="currentContract.projectId" class="text-xs text-slate-500 mt-1">프로젝트 ID · {{ currentContract.projectId }}</p>
-                    </div>
-
-                    <div class="grid grid-cols-2 gap-4">
+            <div v-else class="space-y-6">
+                <div class="bg-slate-900 rounded-2xl border border-white/5 overflow-hidden shadow-lg">
+                    <div class="px-6 py-4 border-b border-white/5 flex items-start justify-between gap-4">
                         <div>
-                            <h4 class="text-xs font-semibold text-slate-500 mb-1 uppercase tracking-wider">총 계약금액</h4>
-                            <p class="text-base font-bold text-white">{{ formatCurrency(currentContract.budget) }}</p>
-                        </div>
-                        <div>
-                            <h4 class="text-xs font-semibold text-slate-500 mb-1 uppercase tracking-wider">계약 기간</h4>
-                            <p class="text-base font-bold text-white">
-                                {{ formatDate(currentContract.startDate) }} ~ {{ formatDate(currentContract.endDate) }}
+                            <p class="text-xs uppercase tracking-[0.18em] text-slate-500 mb-2">현재 계약</p>
+                            <h3 class="text-xl font-bold text-white">{{ currentContract.projectName }}</h3>
+                            <p class="text-sm text-slate-400 mt-1">
+                                계약번호 · {{ currentContract.contractId }}
                             </p>
                         </div>
-                    </div>
-
-                    <div class="border-t border-white/5 pt-4">
-                        <h4 class="text-xs font-semibold text-slate-500 mb-3 uppercase tracking-wider">서명 현황</h4>
-                        <div class="flex items-center gap-4">
-                            <!-- Employer Status -->
-                            <div class="flex-1 flex items-center gap-2 p-3 bg-slate-800 rounded-lg border border-white/5">
-                                <div :class="['w-2 h-2 rounded-full', currentContract.employerSignedDate ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]' : 'bg-slate-600']"></div>
-                                <span class="text-sm font-medium text-slate-300">고용주</span>
-                                <span v-if="currentContract.employerSignedDate" class="ml-auto text-xs text-emerald-500 font-bold">완료</span>
-                            </div>
-                            <!-- Freelancer Status -->
-                            <div class="flex-1 flex items-center gap-2 p-3 bg-slate-800 rounded-lg border border-white/5">
-                                <div :class="['w-2 h-2 rounded-full', currentContract.freelancerSignedDate ? 'bg-emerald-500 shadow-[0_0_8px_rgba(16,185,129,0.5)]' : 'bg-slate-600']"></div>
-                                <span class="text-sm font-medium text-slate-300">프리랜서</span>
-                                <span v-if="currentContract.freelancerSignedDate" class="ml-auto text-xs text-emerald-500 font-bold">완료</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <!-- Action Buttons -->
-                    <div class="pt-2 flex flex-col gap-3">
-                        <button class="w-full py-2.5 border border-white/10 bg-slate-800 text-slate-300 font-medium rounded-lg hover:bg-slate-700 hover:text-white transition-colors flex items-center justify-center gap-2">
-                             <FileIcon class="w-4 h-4" /> 계약서 미리보기 (PDF)
-                        </button>
-                        
-                        <template v-if="!hasSigned">
-                            <button 
-                                @click="openSignatureModal"
-                                class="w-full py-2.5 bg-emerald-600 text-white font-bold rounded-lg hover:bg-emerald-500 transition-colors shadow-lg shadow-emerald-900/20 flex items-center justify-center gap-2"
-                            >
-                                <PenToolIcon class="w-4 h-4" /> 서명하고 수락하기
-                            </button>
-                            <button
-                                v-if="!isEmployer"
-                                @click="rejectContract"
-                                class="w-full py-2.5 bg-rose-500/10 border border-rose-500/30 text-rose-300 font-semibold rounded-lg hover:bg-rose-500/20 transition-colors flex items-center justify-center gap-2"
-                            >
-                                거절하기
-                            </button>
-                        </template>
-                        <div v-else class="text-center py-2 text-sm text-emerald-500 font-medium bg-emerald-500/10 rounded-lg border border-emerald-500/20">
-                            이미 서명을 완료했습니다. 상대방을 기다리는 중입니다.
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Case 2.5: Rejected Contract -->
-            <div v-else-if="currentContract.status === 'REJECTED'" class="bg-slate-900 rounded-xl shadow-lg border border-white/5 overflow-hidden">
-                <div class="bg-rose-500/10 px-6 py-4 border-b border-rose-500/20 flex items-center gap-3">
-                    <ClockIcon class="w-5 h-5 text-rose-400" />
-                    <span class="font-bold text-rose-400">계약이 거절되었습니다</span>
-                </div>
-                <div class="p-6 space-y-4">
-                    <div class="text-sm text-slate-300">
-                        상대방이 계약을 거절했습니다. 새로운 조건으로 다시 제안할 수 있습니다.
-                    </div>
-                    <div class="flex flex-col gap-3">
-                        <button
-                            v-if="isEmployer"
-                            @click="initiateContract"
-                            class="w-full py-2.5 bg-emerald-600 text-white font-bold rounded-lg hover:bg-emerald-500 transition-colors shadow-lg shadow-emerald-900/20 flex items-center justify-center gap-2"
+                        <div
+                            :class="currentStatusConfig.badgeClass"
+                            class="inline-flex items-center gap-2 px-3 py-2 rounded-full text-xs font-semibold border"
                         >
-                            계약서 다시 작성하기
-                        </button>
+                            <component :is="currentStatusConfig.icon" class="w-4 h-4" />
+                            {{ currentStatusConfig.label }}
+                        </div>
+                    </div>
+
+                    <div class="p-6 space-y-6">
+                        <div class="rounded-2xl border border-white/5 bg-slate-950/70 p-4">
+                            <p class="text-sm text-slate-300 leading-relaxed">
+                                {{ currentStatusConfig.description }}
+                            </p>
+                        </div>
+
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div class="rounded-xl bg-slate-950/70 border border-white/5 p-4">
+                                <p class="text-xs text-slate-500 uppercase tracking-wider">상대방</p>
+                                <p class="text-base font-semibold text-white mt-2">{{ otherParticipantName }}</p>
+                            </div>
+                            <div class="rounded-xl bg-slate-950/70 border border-white/5 p-4">
+                                <p class="text-xs text-slate-500 uppercase tracking-wider">총 계약금액</p>
+                                <p class="text-base font-semibold text-white mt-2">{{ formatCurrency(currentContract.budget) }}</p>
+                            </div>
+                            <div class="rounded-xl bg-slate-950/70 border border-white/5 p-4">
+                                <p class="text-xs text-slate-500 uppercase tracking-wider">계약 기간</p>
+                                <p class="text-base font-semibold text-white mt-2">
+                                    {{ formatDate(currentContract.startDate) }} ~ {{ formatDate(currentContract.endDate) }}
+                                </p>
+                            </div>
+                            <div class="rounded-xl bg-slate-950/70 border border-white/5 p-4">
+                                <p class="text-xs text-slate-500 uppercase tracking-wider">정산일</p>
+                                <p class="text-base font-semibold text-white mt-2">
+                                    매월 {{ currentContract.paymentDay || 25 }}일
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="space-y-3">
+                            <div class="flex items-center justify-between gap-3 rounded-xl bg-slate-950/70 border border-white/5 p-4">
+                                <div>
+                                    <p class="text-sm font-semibold text-white">고용주 서명</p>
+                                    <p class="text-xs text-slate-500 mt-1">계약 화면에서만 서명할 수 있습니다.</p>
+                                </div>
+                                <span
+                                    :class="currentContract.employerSignedDate ? 'text-emerald-400 border-emerald-500/30 bg-emerald-500/10' : 'text-slate-400 border-white/10 bg-white/5'"
+                                    class="px-3 py-1.5 rounded-full text-xs font-semibold border"
+                                >
+                                    {{ currentContract.employerSignedDate ? '완료' : '대기중' }}
+                                </span>
+                            </div>
+                            <div class="flex items-center justify-between gap-3 rounded-xl bg-slate-950/70 border border-white/5 p-4">
+                                <div>
+                                    <p class="text-sm font-semibold text-white">프리랜서 서명</p>
+                                    <p class="text-xs text-slate-500 mt-1">계약 화면에서만 서명할 수 있습니다.</p>
+                                </div>
+                                <span
+                                    :class="currentContract.freelancerSignedDate ? 'text-emerald-400 border-emerald-500/30 bg-emerald-500/10' : 'text-slate-400 border-white/10 bg-white/5'"
+                                    class="px-3 py-1.5 rounded-full text-xs font-semibold border"
+                                >
+                                    {{ currentContract.freelancerSignedDate ? '완료' : '대기중' }}
+                                </span>
+                            </div>
+                        </div>
+
                         <button
-                            v-else
-                            @click="requestContract()"
-                            class="w-full py-2.5 bg-slate-800 border border-white/10 text-slate-300 text-sm font-medium rounded-lg hover:bg-slate-700 hover:text-white transition-colors"
+                            @click="openContractPage"
+                            class="w-full inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl bg-emerald-600 text-white font-semibold hover:bg-emerald-500 transition-colors shadow-lg shadow-emerald-950/30"
                         >
-                            계약서 다시 요청하기
+                            {{ primaryActionLabel }}
+                            <ArrowRightIcon class="w-4 h-4" />
                         </button>
                     </div>
                 </div>
-            </div>
-
-            <!-- Case 3: Active / Completed Contract -->
-            <div v-else class="space-y-6">
-                <!-- Status Card -->
-                <div class="bg-slate-900 rounded-xl shadow-lg border border-white/5 p-6">
-                    <div class="flex justify-between items-start mb-4">
-                        <div>
-                            <h3 class="text-lg font-bold text-white">{{ currentContract.projectName }}</h3>
-                            <p v-if="currentContract.projectId" class="text-xs text-slate-500 mt-1">프로젝트 ID · {{ currentContract.projectId }}</p>
-                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-bold bg-emerald-500/10 text-emerald-500 border border-emerald-500/20 mt-2">
-                                {{ currentContract.status === 'IN_PROGRESS' ? '진행중' : '완료됨' }}
-                            </span>
-                        </div>
-                        <button class="text-sm text-blue-400 hover:text-blue-300 font-medium transition-colors">상세보기</button>
-                    </div>
-                    
-                     <div class="grid grid-cols-2 gap-4 mt-4">
-                        <div>
-                            <p class="text-xs text-slate-500">계약 시작일</p>
-                            <p class="text-sm font-semibold text-slate-200">{{ formatDate(currentContract.startDate) }}</p>
-                        </div>
-                         <div>
-                            <p class="text-xs text-slate-500">계약 종료일</p>
-                            <p class="text-sm font-semibold text-slate-200">{{ formatDate(currentContract.endDate) }}</p>
-                        </div>
-                     </div>
-                </div>
-
-                <!-- Settlement Summary -->
-                <div class="bg-slate-900 rounded-xl shadow-lg border border-white/5 p-6">
-                    <h4 class="font-bold text-white mb-4 flex items-center gap-2">
-                        <DollarSignIcon class="w-4 h-4 text-slate-500" /> 정산 현황
-                    </h4>
-                    
-                    <div class="space-y-4">
-                        <!-- Upcoming Payment -->
-                         <div class="p-4 bg-blue-500/10 rounded-lg border border-blue-500/20">
-                            <div class="flex justify-between items-center mb-1">
-                                <span class="text-sm font-medium text-blue-400">다음 정산일</span>
-                                <span class="text-sm font-bold text-blue-400">D-12</span>
-                            </div>
-                            <p class="text-xs text-blue-300">매월 {{ currentContract.paymentDay }}일 지급 예정</p>
-                        </div>
-
-                         <!-- Payment History Preview -->
-                         <div class="space-y-2">
-                            <div class="flex justify-between items-center text-sm p-2 hover:bg-white/5 rounded transition-colors">
-                                <span class="text-slate-400">1차 정산금</span>
-                                <span class="font-medium text-emerald-500">지급 완료</span>
-                            </div>
-                             <div class="flex justify-between items-center text-sm p-2 hover:bg-white/5 rounded transition-colors">
-                                <span class="text-slate-400">2차 정산금</span>
-                                <span class="font-medium text-orange-400">처리중</span>
-                            </div>
-                         </div>
-                    </div>
-                </div>
-                
-                 <button class="w-full py-3 border border-white/10 bg-slate-800 text-slate-300 font-medium rounded-xl hover:bg-slate-700 hover:text-white transition-colors flex items-center justify-center gap-2 shadow-lg">
-                    <FileTextIcon class="w-4 h-4" /> 최종 계약서 다운로드
-                </button>
             </div>
         </div>
     </div>
-
-    <!-- Create Contract Modal -->
-    <div
-        v-if="isCreateModalOpen"
-        class="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
-    >
-        <div class="w-full max-w-xl rounded-3xl border border-white/10 bg-gradient-to-br from-slate-900 to-slate-950 p-6 text-white shadow-2xl">
-            <div class="flex items-center justify-between mb-6">
-                <h3 class="text-lg font-bold">계약서 작성</h3>
-                <button class="text-slate-400 hover:text-white text-sm" @click="closeCreateModal">닫기</button>
-            </div>
-
-            <div class="space-y-4">
-                <div>
-                    <label class="text-xs text-slate-400">프로젝트명</label>
-                    <input
-                        v-model="createForm.projectName"
-                        type="text"
-                        class="mt-2 w-full rounded-xl bg-slate-800/80 border border-white/10 px-4 py-2.5 text-sm text-white focus:outline-none focus:border-emerald-400/60"
-                        placeholder="프로젝트명을 입력하세요"
-                    />
-                </div>
-                <div>
-                    <label class="text-xs text-slate-400">프로젝트 고유번호</label>
-                    <input
-                        v-model="createForm.projectId"
-                        type="text"
-                        readonly
-                        class="mt-2 w-full rounded-xl bg-slate-800/80 border border-white/10 px-4 py-2.5 text-sm text-slate-300 focus:outline-none"
-                    />
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                        <label class="text-xs text-slate-400">시작일</label>
-                        <input
-                            v-model="createForm.startDate"
-                            type="date"
-                            class="mt-2 w-full rounded-xl bg-slate-800/80 border border-white/10 px-4 py-2.5 text-sm text-white focus:outline-none focus:border-emerald-400/60"
-                        />
-                    </div>
-                    <div>
-                        <label class="text-xs text-slate-400">종료일</label>
-                        <input
-                            v-model="createForm.endDate"
-                            type="date"
-                            class="mt-2 w-full rounded-xl bg-slate-800/80 border border-white/10 px-4 py-2.5 text-sm text-white focus:outline-none focus:border-emerald-400/60"
-                        />
-                    </div>
-                </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                        <label class="text-xs text-slate-400">총 계약금액</label>
-                        <input
-                            v-model.number="createForm.budget"
-                            type="number"
-                            min="0"
-                            class="mt-2 w-full rounded-xl bg-slate-800/80 border border-white/10 px-4 py-2.5 text-sm text-white focus:outline-none focus:border-emerald-400/60"
-                            placeholder="예: 10000000"
-                        />
-                    </div>
-                    <div>
-                        <label class="text-xs text-slate-400">지급일</label>
-                        <input
-                            v-model.number="createForm.paymentDay"
-                            type="number"
-                            min="1"
-                            max="31"
-                            class="mt-2 w-full rounded-xl bg-slate-800/80 border border-white/10 px-4 py-2.5 text-sm text-white focus:outline-none focus:border-emerald-400/60"
-                            placeholder="예: 25"
-                        />
-                    </div>
-                </div>
-                <div v-if="createError" class="text-xs text-rose-400">{{ createError }}</div>
-            </div>
-
-            <div class="mt-6 flex gap-3">
-                <button
-                    class="flex-1 py-3 rounded-xl bg-white/10 border border-white/10 text-sm font-semibold text-white hover:bg-white/20 transition-colors"
-                    @click="closeCreateModal"
-                >
-                    취소
-                </button>
-                <button
-                    class="flex-1 py-3 rounded-xl bg-emerald-600 text-sm font-semibold text-white hover:bg-emerald-500 transition-colors"
-                    @click="createContract"
-                >
-                    작성 완료
-                </button>
-            </div>
-        </div>
-    </div>
-
-    <SignaturePadModal
-        v-if="isSignatureModalOpen && authStore.user"
-        :signerName="authStore.user.name"
-        @sign="handleSignature"
-        @close="isSignatureModalOpen = false"
-    />
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
 import { useAuthStore } from '@/stores/authStore';
 import { useChatStore } from '@/stores/chatStore';
 import { useContractStore } from '@/stores/contractStore';
-import { useJobStore } from '@/stores/jobStore';
-import { useFreelancerStore } from '@/stores/freelancerStore';
-import SignaturePadModal from '@/views/employer/Contracts/components/SignaturePadModal.vue';
-import { 
-    FileText as FileTextIcon, 
-    Clock as ClockIcon, 
-    PenTool as PenToolIcon, 
-    File as FileIcon,
-    DollarSign as DollarSignIcon
+import {
+    AlertCircle as AlertCircleIcon,
+    ArrowRight as ArrowRightIcon,
+    CheckCircle as CheckCircleIcon,
+    Clock as ClockIcon,
+    FileText as FileTextIcon,
+    Loader2 as Loader2Icon,
 } from 'lucide-vue-next';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
@@ -324,178 +159,165 @@ const props = defineProps<{
 const authStore = useAuthStore();
 const chatStore = useChatStore();
 const contractStore = useContractStore();
-const jobStore = useJobStore();
-const freelancerStore = useFreelancerStore();
+const router = useRouter();
 
-const currentRoom = computed(() => chatStore.rooms.find(r => r.id === props.roomId));
-const currentContract = computed(() => {
-    if (!currentRoom.value?.contractId) return null;
-    return contractStore.contracts.find(c => c.id === currentRoom.value?.contractId);
-});
-
+const currentRoom = computed(() => chatStore.rooms.find((room) => room.id === props.roomId));
 const isEmployer = computed(() => authStore.user?.role === 'EMPLOYER');
-const isCreateModalOpen = ref(false);
-const isSignatureModalOpen = ref(false);
-const createError = ref('');
-const createForm = ref({
-    projectName: '',
-    projectId: '',
-    startDate: '',
-    endDate: '',
-    budget: 0,
-    paymentDay: 25
-});
-
-const hasSigned = computed(() => {
-    if (!currentContract.value || !authStore.user) return false;
-    return isEmployer.value 
-        ? !!currentContract.value.employerSignedDate 
-        : !!currentContract.value.freelancerSignedDate;
-});
-
 const otherParticipantId = computed(() => {
     if (!currentRoom.value) return null;
     return chatStore.getOtherParticipantId(currentRoom.value) || null;
+});
+const otherParticipantName = computed(() => {
+    if (!currentRoom.value) return '알 수 없음';
+    return chatStore.getOtherParticipantName(currentRoom.value);
+});
+
+function parseParticipantNumericId(participantId: string | null) {
+    if (!participantId) return null;
+    const matchedParticipant = String(participantId).match(/^[efa](\d+)$/i);
+    if (matchedParticipant) {
+        return Number(matchedParticipant[1]);
+    }
+    const numericId = Number(participantId);
+    return Number.isFinite(numericId) ? numericId : null;
+}
+
+const roomParticipantIds = computed(() => {
+    if (!authStore.user || !otherParticipantId.value) return null;
+
+    const myUserId = Number(authStore.user.id);
+    const counterpartId = parseParticipantNumericId(otherParticipantId.value);
+    if (!Number.isFinite(myUserId) || !Number.isFinite(counterpartId)) return null;
+
+    return {
+        employerId: isEmployer.value ? myUserId : counterpartId,
+        freelancerId: isEmployer.value ? counterpartId : myUserId,
+    };
+});
+
+const relatedContracts = computed(() => {
+    if (!roomParticipantIds.value) return [];
+
+    return contractStore.contracts.filter(
+        (contract) =>
+            Number(contract.employerId) === roomParticipantIds.value!.employerId &&
+            Number(contract.freelancerId) === roomParticipantIds.value!.freelancerId
+    );
+});
+
+const currentContract = computed(() => {
+    const linkedContract = contractStore.findContractByAnyId(currentRoom.value?.contractId);
+    if (linkedContract) return linkedContract;
+    if (!roomParticipantIds.value) return null;
+
+    return contractStore.findContractByParticipants(
+        roomParticipantIds.value.employerId,
+        roomParticipantIds.value.freelancerId
+    );
+});
+
+const hasMultipleContractCandidates = computed(() => {
+    return !currentRoom.value?.contractId && !currentContract.value && relatedContracts.value.length > 1;
+});
+
+const isContractLookupPending = computed(() => {
+    return contractStore.isContractsLoading && !contractStore.hasFetchedContracts && !currentContract.value;
+});
+
+const statusConfig = {
+    WAITING_SIGNATURE: {
+        label: '서명 대기중',
+        badgeClass: 'text-amber-300 border-amber-500/30 bg-amber-500/10',
+        description: '실제 서명은 계약 화면에서만 진행합니다. 채팅에서는 현재 서명 진행 상태만 확인할 수 있습니다.',
+        icon: ClockIcon,
+    },
+    IN_PROGRESS: {
+        label: '진행중',
+        badgeClass: 'text-sky-300 border-sky-500/30 bg-sky-500/10',
+        description: '계약이 활성화되었습니다. 세부 계약서와 정산 상태는 계약/정산 화면에서 확인하세요.',
+        icon: CheckCircleIcon,
+    },
+    COMPLETED: {
+        label: '완료됨',
+        badgeClass: 'text-emerald-300 border-emerald-500/30 bg-emerald-500/10',
+        description: '완료된 계약입니다. 최종 계약 내용과 정산 내역은 계약 화면에서 확인하세요.',
+        icon: CheckCircleIcon,
+    },
+    REJECTED: {
+        label: '거절됨',
+        badgeClass: 'text-rose-300 border-rose-500/30 bg-rose-500/10',
+        description: '거절된 계약입니다. 조건을 조정해 다시 진행하려면 계약 화면에서 새 계약을 작성하세요.',
+        icon: AlertCircleIcon,
+    },
+} as const;
+
+const currentStatusConfig = computed(() => {
+    if (!currentContract.value) {
+        return statusConfig.WAITING_SIGNATURE;
+    }
+    return statusConfig[currentContract.value.status];
+});
+
+const primaryActionLabel = computed(() => {
+    if (!currentContract.value) {
+        if (hasMultipleContractCandidates.value) return '계약 목록으로 이동';
+        return isEmployer.value ? '계약서 작성 화면으로 이동' : '계약 목록으로 이동';
+    }
+    if (currentContract.value.status === 'REJECTED' && isEmployer.value) {
+        return '계약서 다시 작성 화면으로 이동';
+    }
+    return '계약 화면으로 이동';
+});
+
+const emptyStateDescription = computed(() => {
+    if (hasMultipleContractCandidates.value) {
+        return '같은 상대와 연결된 계약이 여러 건 있어 채팅에서는 하나를 임의로 선택하지 않았습니다. 계약 화면에서 정확한 계약을 확인하세요.';
+    }
+    if (isEmployer.value) {
+        return '채팅에서는 계약서를 작성하지 않습니다. 계약서 생성은 계약 화면에서 진행하고, 생성된 상태만 이 탭에서 확인합니다.';
+    }
+    return '채팅에서는 계약 요청이나 서명을 진행하지 않습니다. 계약 상태 확인과 서명은 계약 화면에서 진행하세요.';
 });
 
 function formatCurrency(amount: number) {
     return new Intl.NumberFormat('ko-KR', { style: 'currency', currency: 'KRW' }).format(amount);
 }
 
-function formatDate(date: Date | string) {
+function formatDate(date: Date | string | undefined) {
+    if (!date) return '-';
     return format(new Date(date), 'yyyy.MM.dd', { locale: ko });
 }
 
-function initiateContract() {
-    if (!isEmployer.value) return;
-    const proposalId = currentRoom.value?.relatedProposalId ?? null;
-    const proposal = proposalId
-        ? freelancerStore.proposals.find((item) => item.id === proposalId)
-        : null;
-    const jobId = currentRoom.value?.relatedJobId ?? proposal?.jobId ?? '';
-    const job = jobId ? jobStore.getJobById(jobId) : null;
+function openContractPage() {
+    const targetRouteName =
+        hasMultipleContractCandidates.value
+            ? isEmployer.value
+                ? 'employer.contracts'
+                : 'freelancer.contracts'
+            : !currentContract.value && isEmployer.value
+            ? 'employer.contracts.create'
+            : currentContract.value?.status === 'REJECTED' && isEmployer.value
+              ? 'employer.contracts.create'
+              : isEmployer.value
+                ? 'employer.contracts'
+                : 'freelancer.contracts';
 
-    createForm.value = {
-        projectName: job?.title || proposal?.message?.slice(0, 24) || '프로젝트 계약',
-        projectId: jobId || '',
-        startDate: '',
-        endDate: '',
-        budget: 0,
-        paymentDay: 25
-    };
-    createError.value = '';
-    isCreateModalOpen.value = true;
-}
-
-function openSignatureModal() {
-    if (!currentContract.value) return;
-    isSignatureModalOpen.value = true;
-}
-
-function requestContract() {
-    // Fixed system message for contract request
-    chatStore.sendSystemMessage(props.roomId, '계약서를 요청했습니다.', 'SYSTEM');
-    alert('고용주에게 계약서 작성을 요청했습니다.');
-}
-
-function closeCreateModal() {
-    isCreateModalOpen.value = false;
-}
-
-function parseParticipantId(participantId: string | null) {
-    if (!participantId) return null;
-    const match = String(participantId).match(/^([ef])(\d+)$/i);
-    if (match) {
-        return { role: match[1].toUpperCase(), id: Number(match[2]) };
-    }
-    const numericId = Number(participantId);
-    return Number.isNaN(numericId) ? null : { role: null, id: numericId };
-}
-
-function createContract() {
-    if (!authStore.user || !currentRoom.value || !otherParticipantId.value) return;
-    if (!createForm.value.projectName.trim()) {
-        createError.value = '프로젝트명을 입력해주세요.';
-        return;
-    }
-    if (!createForm.value.startDate || !createForm.value.endDate) {
-        createError.value = '계약 기간을 선택해주세요.';
-        return;
-    }
-    if (createForm.value.budget <= 0) {
-        createError.value = '계약 금액을 입력해주세요.';
-        return;
-    }
-
-    const other = parseParticipantId(otherParticipantId.value);
-    if (!other?.id) {
-        createError.value = '상대방 정보를 찾을 수 없습니다.';
-        return;
-    }
-
-    const nextId = Math.max(0, ...contractStore.contracts.map((c) => c.id)) + 1;
-    const contract = {
-        id: nextId,
-        contractId: 1000 + nextId,
-        projectName: createForm.value.projectName.trim(),
-        projectId: createForm.value.projectId || undefined,
-        freelancerId: authStore.user.role === 'EMPLOYER' ? other.id : Number(authStore.user.id),
-        employerId: authStore.user.role === 'EMPLOYER' ? Number(authStore.user.id) : other.id,
-        startDate: new Date(createForm.value.startDate),
-        endDate: new Date(createForm.value.endDate),
-        status: 'WAITING_SIGNATURE' as const,
-        budget: createForm.value.budget,
-        commissionRate: 0.05,
-        paymentDay: createForm.value.paymentDay || 25,
-        contractPdfUrl: `/contracts/${1000 + nextId}_contract.pdf`,
-        employerSignature: authStore.user.role === 'EMPLOYER' ? 'signed-by-employer' : undefined,
-        employerSignedDate: authStore.user.role === 'EMPLOYER' ? new Date() : undefined
+    const query: Record<string, string> = {
+        roomId: props.roomId,
     };
 
-    contractStore.addContract(contract);
-    chatStore.updateRoomContract(props.roomId, contract.id);
-    chatStore.sendMessage(
-        '프로젝트 계약 요청',
-        'CONTRACT_ALERT',
-        { contractId: contract.id, status: 'WAITING_SIGNATURE' },
-        props.roomId
-    );
-    chatStore.sendSystemMessage(props.roomId, '계약서가 작성되어 전송되었습니다.');
-
-    isCreateModalOpen.value = false;
-}
-
-function handleSignature(signatureDataUrl: string) {
-    if (!currentContract.value || !authStore.user) return;
-
-    const updates: Record<string, any> = {};
-    if (isEmployer.value) {
-        updates.employerSignature = signatureDataUrl;
-        updates.employerSignedDate = new Date();
-    } else {
-        updates.freelancerSignature = signatureDataUrl;
-        updates.freelancerSignedDate = new Date();
+    if (currentRoom.value?.relatedJobId) {
+        query.jobId = String(currentRoom.value.relatedJobId);
+    }
+    if (currentRoom.value?.relatedProposalId) {
+        query.proposalId = String(currentRoom.value.relatedProposalId);
+    }
+    if (currentContract.value?.contractId) {
+        query.contractId = String(currentContract.value.contractId);
+    } else if (currentRoom.value?.contractId) {
+        query.contractId = String(currentRoom.value.contractId);
     }
 
-    const nextEmployerSigned = updates.employerSignedDate || currentContract.value.employerSignedDate;
-    const nextFreelancerSigned = updates.freelancerSignedDate || currentContract.value.freelancerSignedDate;
-
-    if (nextEmployerSigned && nextFreelancerSigned) {
-        updates.status = 'IN_PROGRESS';
-        updates.signedDate = new Date();
-        chatStore.sendSystemMessage(props.roomId, '계약서 서명이 완료되었습니다.');
-    }
-
-    contractStore.updateContract(currentContract.value.id, updates);
-    isSignatureModalOpen.value = false;
-}
-
-function rejectContract() {
-    if (!currentContract.value) return;
-    if (!confirm('계약을 거절하시겠습니까?')) return;
-    contractStore.updateContract(currentContract.value.id, {
-        status: 'REJECTED'
-    });
-    chatStore.sendSystemMessage(props.roomId, '계약이 거절되었습니다.');
+    router.push({ name: targetRouteName, query });
 }
 </script>

--- a/freebridgefe/src/components/chat/docked/DockedChatWindow.vue
+++ b/freebridgefe/src/components/chat/docked/DockedChatWindow.vue
@@ -138,9 +138,8 @@ const nonSystemMessages = computed(() => messages.value.filter((msg) => msg.type
 const isReadOnly = computed(() => chatStore.isRoomReadOnly(props.roomId));
 
 const otherParticipantName = computed(() => {
-    if (!room.value || !authStore.user) return 'Unknown';
-    const otherId = chatStore.getOtherParticipantId(room.value);
-    return otherId && room.value.participantNames[otherId] ? room.value.participantNames[otherId] : 'User';
+    if (!room.value) return '알 수 없음';
+    return chatStore.getOtherParticipantName(room.value);
 });
 
 function isMyMessage(msg: ChatMessage) {

--- a/freebridgefe/src/components/chat/docked/DockedRoomList.vue
+++ b/freebridgefe/src/components/chat/docked/DockedRoomList.vue
@@ -109,9 +109,7 @@ function openRoom(roomId: string) {
 }
 
 function getOtherParticipantName(room: ChatRoom) {
-    if (!authStore.user) return 'Unknown';
-    const otherId = chatStore.getOtherParticipantId(room);
-    return otherId && room.participantNames[otherId] ? room.participantNames[otherId] : 'User';
+    return chatStore.getOtherParticipantName(room);
 }
 
 function formatDate(date: Date | undefined) {
@@ -138,6 +136,11 @@ const { x, y, isDragging } = useDraggable(windowRef, {
 });
 
 onMounted(() => {
+    if (authStore.isAuthenticated) {
+        chatStore.fetchRooms().catch((error) => {
+            console.error('Failed to refresh chat rooms on docked list mount:', error);
+        });
+    }
     if (windowRef.value) {
         const rect = windowRef.value.getBoundingClientRect();
         x.value = rect.left;

--- a/freebridgefe/src/layouts/PlatformLayout.vue
+++ b/freebridgefe/src/layouts/PlatformLayout.vue
@@ -88,7 +88,32 @@ const dismissAlert = (alertId: string) => {
   chatStore.dismissAlert(alertId);
 };
 
+const refreshChatRooms = async () => {
+  if (!authStore.isAuthenticated) {
+    return;
+  }
+
+  try {
+    await chatStore.fetchRooms();
+  } catch (e) {
+    console.error('Failed to refresh chat rooms:', e);
+  }
+};
+
+const handleWindowFocus = () => {
+  refreshChatRooms();
+};
+
+const handleVisibilityChange = () => {
+  if (document.visibilityState === 'visible') {
+    refreshChatRooms();
+  }
+};
+
 onMounted(async () => {
+  window.addEventListener('focus', handleWindowFocus);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+
   if (authStore.isAuthenticated) {
     try {
       await chatStore.connectWebSocket();
@@ -100,6 +125,8 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  window.removeEventListener('focus', handleWindowFocus);
+  document.removeEventListener('visibilitychange', handleVisibilityChange);
   chatStore.disconnectWebSocket();
 });
 
@@ -110,6 +137,10 @@ watch(
     const isNowChatRoute = newPath.startsWith('/chat');
 
     chatStore.setMainChatVisible(isNowChatRoute);
+
+    if (isNowChatRoute && authStore.isAuthenticated) {
+      refreshChatRooms();
+    }
 
     if (wasChatRoute && !isNowChatRoute) {
       chatStore.resetDockedUIState();

--- a/freebridgefe/src/layouts/PlatformLayout.vue
+++ b/freebridgefe/src/layouts/PlatformLayout.vue
@@ -88,25 +88,37 @@ const dismissAlert = (alertId: string) => {
   chatStore.dismissAlert(alertId);
 };
 
-const refreshChatRooms = async () => {
+let refreshChatRoomsPromise: Promise<void> | null = null;
+
+const refreshChatRooms = () => {
   if (!authStore.isAuthenticated) {
-    return;
+    return Promise.resolve();
   }
 
-  try {
-    await chatStore.fetchRooms();
-  } catch (e) {
-    console.error('Failed to refresh chat rooms:', e);
+  if (refreshChatRoomsPromise) {
+    return refreshChatRoomsPromise;
   }
+
+  refreshChatRoomsPromise = (async () => {
+    try {
+      await chatStore.fetchRooms();
+    } catch (e) {
+      console.error('Failed to refresh chat rooms:', e);
+    } finally {
+      refreshChatRoomsPromise = null;
+    }
+  })();
+
+  return refreshChatRoomsPromise;
 };
 
-const handleWindowFocus = () => {
-  refreshChatRooms();
+const handleWindowFocus = async () => {
+  await refreshChatRooms();
 };
 
-const handleVisibilityChange = () => {
+const handleVisibilityChange = async () => {
   if (document.visibilityState === 'visible') {
-    refreshChatRooms();
+    await refreshChatRooms();
   }
 };
 
@@ -117,7 +129,7 @@ onMounted(async () => {
   if (authStore.isAuthenticated) {
     try {
       await chatStore.connectWebSocket();
-      await chatStore.fetchRooms();
+      await refreshChatRooms();
     } catch (e) {
       console.error('Failed to initialize chat:', e);
     }

--- a/freebridgefe/src/stores/chatStore.ts
+++ b/freebridgefe/src/stores/chatStore.ts
@@ -52,11 +52,11 @@ export const useChatStore = defineStore('chat', () => {
         if (!raw) return [];
 
         const normalized = raw.toLowerCase();
-        const variants = new Set<string>([normalized]);
-
         if (/^[efa]\d+$/i.test(normalized)) {
-            variants.add(normalized.slice(1));
+            return [normalized];
         }
+
+        const variants = new Set<string>([normalized]);
 
         if (/^\d+$/.test(normalized)) {
             variants.add(`e${normalized}`);

--- a/freebridgefe/src/stores/chatStore.ts
+++ b/freebridgefe/src/stores/chatStore.ts
@@ -144,6 +144,40 @@ export const useChatStore = defineStore('chat', () => {
         return getParticipantName(room, otherId) || '알 수 없음';
     }
 
+    function normalizeParticipantListForCurrentUser(participants: Array<string | number>): string[] {
+        const myNormalizedId = getCurrentChatParticipantId();
+        const myIds = getMyParticipantIds();
+        const counterpartRole = getCounterpartRole();
+        const myIdVariants = new Set(myIds.flatMap((id) => buildParticipantIdVariants(id, authStore.user?.role)));
+
+        return Array.from(
+            new Set(
+                participants
+                    .map((id) => {
+                        const sid = String(id).trim();
+                        if (!sid) return sid;
+
+                        const isMine = buildParticipantIdVariants(sid).some((candidate) => myIdVariants.has(candidate));
+                        if (isMine) {
+                            return myNormalizedId ?? normalizeParticipantId(sid, authStore.user?.role);
+                        }
+
+                        return normalizeParticipantId(sid, counterpartRole);
+                    })
+                    .filter(Boolean)
+            )
+        );
+    }
+
+    function participantsMatch(leftParticipants: Array<string | number>, rightParticipants: Array<string | number>): boolean {
+        const normalizedLeft = normalizeParticipantListForCurrentUser(leftParticipants);
+        const normalizedRight = normalizeParticipantListForCurrentUser(rightParticipants);
+
+        return normalizedLeft.length === normalizedRight.length &&
+            normalizedLeft.every((participantId) => normalizedRight.includes(participantId)) &&
+            normalizedRight.every((participantId) => normalizedLeft.includes(participantId));
+    }
+
     // ── 상태 ───────────────────────────────────────────────────────────────
     const rooms = ref<ChatRoom[]>([]);
     const messages = ref<{ [roomId: string]: ChatMessage[] }>({});
@@ -614,22 +648,7 @@ export const useChatStore = defineStore('chat', () => {
         context: any
     ) {
         const myNormalizedId = getCurrentChatParticipantId();
-        const myIds = getMyParticipantIds();
-        const counterpartRole = getCounterpartRole();
-        const myIdVariants = new Set(myIds.flatMap((id) => buildParticipantIdVariants(id, authStore.user?.role)));
-        const normalizedParticipants = Array.from(
-            new Set(
-                participants.map((id) => {
-                    const sid = String(id);
-                    if (!sid) return sid;
-                    const isMine = buildParticipantIdVariants(sid).some((candidate) => myIdVariants.has(candidate));
-                    if (isMine) {
-                        return myNormalizedId ?? normalizeParticipantId(sid, authStore.user?.role);
-                    }
-                    return normalizeParticipantId(sid, counterpartRole);
-                })
-            )
-        );
+        const normalizedParticipants = normalizeParticipantListForCurrentUser(participants);
 
         const normalizedNames = normalizedParticipants.reduce<Record<string, string>>((acc, participantId) => {
             const resolvedName = resolveParticipantNameFromMap(names, participantId);
@@ -648,8 +667,7 @@ export const useChatStore = defineStore('chat', () => {
 
         const existingRoom = rooms.value.find(
             (r) =>
-                r.participants.every((p) => normalizedParticipants.includes(p)) &&
-                normalizedParticipants.every((p) => r.participants.includes(p)) &&
+                participantsMatch(r.participants, normalizedParticipants) &&
                 (
                     (r.relatedApplicationId && context.relatedApplicationId && r.relatedApplicationId === context.relatedApplicationId) ||
                     (r.relatedProposalId && context.relatedProposalId && r.relatedProposalId === context.relatedProposalId) ||

--- a/freebridgefe/src/stores/chatStore.ts
+++ b/freebridgefe/src/stores/chatStore.ts
@@ -3,7 +3,7 @@ import { ref, computed } from 'vue';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 import { useAuthStore } from '@/stores/authStore';
-import type { ChatRoom, ChatMessage } from '@/types';
+import type { ChatRoom, ChatMessage, UserRole } from '@/types';
 import { getMyChatRooms, getChatMessages, createChatRoom as apiCreateRoom } from '@/api/chatApi';
 import { API_BASE_URL, getAccessToken } from '@/api/axiosInstance';
 import { CHAT_MUTED_ROOMS_KEY } from '@/constants/chatUi';
@@ -30,17 +30,76 @@ export const useChatStore = defineStore('chat', () => {
         createdAt: Date;
     };
 
+    function normalizeParticipantId(id: string | number, role?: UserRole): string {
+        const raw = String(id).trim();
+        if (!raw) return raw;
+
+        const normalized = raw.toLowerCase();
+        if (/^[efa]\d+$/i.test(normalized)) {
+            return normalized;
+        }
+
+        if (/^\d+$/.test(normalized) && role) {
+            const prefix = role === 'EMPLOYER' ? 'e' : 'f';
+            return `${prefix}${normalized}`;
+        }
+
+        return raw;
+    }
+
+    function buildParticipantIdVariants(id: string | number, role?: UserRole): string[] {
+        const raw = String(id).trim();
+        if (!raw) return [];
+
+        const normalized = raw.toLowerCase();
+        const variants = new Set<string>([normalized]);
+
+        if (/^[efa]\d+$/i.test(normalized)) {
+            variants.add(normalized.slice(1));
+        }
+
+        if (/^\d+$/.test(normalized)) {
+            variants.add(`e${normalized}`);
+            variants.add(`f${normalized}`);
+            variants.add(`a${normalized}`);
+        }
+
+        const roleBasedId = normalizeParticipantId(normalized, role);
+        if (roleBasedId) {
+            variants.add(roleBasedId.toLowerCase());
+        }
+
+        return Array.from(variants);
+    }
+
+    function idsMatch(leftId: string | number, rightId: string | number, rightRole?: UserRole): boolean {
+        const leftVariants = new Set(buildParticipantIdVariants(leftId));
+        return buildParticipantIdVariants(rightId, rightRole).some((candidate) => leftVariants.has(candidate));
+    }
+
+    function resolveParticipantNameFromMap(
+        participantNames: Record<string, string> | undefined,
+        participantId: string | number
+    ): string | undefined {
+        if (!participantNames) return undefined;
+
+        const matchedEntry = Object.entries(participantNames).find(
+            ([candidateId, candidateName]) => Boolean(candidateName?.trim()) && idsMatch(candidateId, participantId)
+        );
+
+        return matchedEntry?.[1]?.trim() || undefined;
+    }
+
+    function getCounterpartRole(): UserRole | undefined {
+        if (!authStore.user) return undefined;
+        return authStore.user.role === 'EMPLOYER' ? 'FREELANCER' : 'EMPLOYER';
+    }
+
     // ── 참가자 ID 유틸 ─────────────────────────────────────────────────────
     function getCurrentChatParticipantId(): string | null {
         if (!authStore.user) return null;
 
-        const rawId = String(authStore.user.id);
-        if (/^[ef]\d+$/i.test(rawId)) {
-            return rawId;
-        }
-
-        const prefix = authStore.user.role === 'EMPLOYER' ? 'e' : 'f';
-        return `${prefix}${rawId}`;
+        return normalizeParticipantId(authStore.user.id, authStore.user.role) || null;
     }
 
     function getMyParticipantIds(): string[] {
@@ -54,7 +113,35 @@ export const useChatStore = defineStore('chat', () => {
 
     function getOtherParticipantId(room: ChatRoom): string | undefined {
         const myIds = getMyParticipantIds();
-        return room.participants.find((id) => !myIds.includes(String(id)));
+        return room.participants.find(
+            (participantId) => !myIds.some((myId) => idsMatch(participantId, myId, authStore.user?.role))
+        );
+    }
+
+    function getParticipantName(room: ChatRoom, participantId: string): string | undefined {
+        const normalizedParticipantId = normalizeIdForRoom(room, participantId);
+        const resolvedName =
+            resolveParticipantNameFromMap(room.participantNames, normalizedParticipantId) ??
+            resolveParticipantNameFromMap(room.participantNames, participantId);
+
+        if (resolvedName) {
+            return resolvedName;
+        }
+
+        const currentParticipantId = getCurrentChatParticipantId();
+        if (currentParticipantId && idsMatch(normalizedParticipantId, currentParticipantId, authStore.user?.role)) {
+            return authStore.user?.role === 'EMPLOYER'
+                ? authStore.user.companyName || authStore.user.name
+                : authStore.user?.name;
+        }
+
+        return undefined;
+    }
+
+    function getOtherParticipantName(room: ChatRoom): string {
+        const otherId = getOtherParticipantId(room);
+        if (!otherId) return '알 수 없음';
+        return getParticipantName(room, otherId) || '알 수 없음';
     }
 
     // ── 상태 ───────────────────────────────────────────────────────────────
@@ -122,7 +209,7 @@ export const useChatStore = defineStore('chat', () => {
     }
 
     function triggerIncomingAlert(room: ChatRoom, message: ChatMessage) {
-        const senderName = room.participantNames[message.senderId] || '새 메시지';
+        const senderName = getParticipantName(room, message.senderId) || '새 메시지';
         const nextAlert: ChatAlert = {
             id: `alert-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
             roomId: room.id,
@@ -394,12 +481,21 @@ export const useChatStore = defineStore('chat', () => {
 
     // ── Getters ────────────────────────────────────────────────────────────
     function normalizeIdForRoom(room: ChatRoom, id: string): string {
-        const raw = String(id);
-        if (/^[ef]\d+$/i.test(raw)) return raw.toLowerCase();
-        const possibleEmployer = `e${raw}`;
-        const possibleFreelancer = `f${raw}`;
-        if (room.participantNames[possibleEmployer]) return possibleEmployer;
-        if (room.participantNames[possibleFreelancer]) return possibleFreelancer;
+        const raw = String(id).trim();
+        if (!raw) return raw;
+
+        const matchedParticipant = room.participants.find((participantId) => idsMatch(participantId, raw));
+        if (matchedParticipant) {
+            return String(matchedParticipant);
+        }
+
+        const matchedParticipantNameKey = Object.keys(room.participantNames || {}).find((participantId) =>
+            idsMatch(participantId, raw)
+        );
+        if (matchedParticipantNameKey) {
+            return matchedParticipantNameKey;
+        }
+
         return raw;
     }
 
@@ -517,37 +613,62 @@ export const useChatStore = defineStore('chat', () => {
         names: { [key: string]: string },
         context: any
     ) {
-        const myIds = getMyParticipantIds();
         const myNormalizedId = getCurrentChatParticipantId();
+        const myIds = getMyParticipantIds();
+        const counterpartRole = getCounterpartRole();
+        const myIdVariants = new Set(myIds.flatMap((id) => buildParticipantIdVariants(id, authStore.user?.role)));
         const normalizedParticipants = Array.from(
             new Set(
                 participants.map((id) => {
                     const sid = String(id);
-                    if (myNormalizedId && myIds.includes(sid)) return myNormalizedId;
-                    return sid;
+                    if (!sid) return sid;
+                    const isMine = buildParticipantIdVariants(sid).some((candidate) => myIdVariants.has(candidate));
+                    if (isMine) {
+                        return myNormalizedId ?? normalizeParticipantId(sid, authStore.user?.role);
+                    }
+                    return normalizeParticipantId(sid, counterpartRole);
                 })
             )
         );
+
+        const normalizedNames = normalizedParticipants.reduce<Record<string, string>>((acc, participantId) => {
+            const resolvedName = resolveParticipantNameFromMap(names, participantId);
+            if (resolvedName) {
+                acc[participantId] = resolvedName;
+            }
+            return acc;
+        }, {});
+
+        if (myNormalizedId && authStore.user) {
+            normalizedNames[myNormalizedId] = normalizedNames[myNormalizedId] ||
+                (authStore.user.role === 'EMPLOYER'
+                    ? authStore.user.companyName || authStore.user.name
+                    : authStore.user.name);
+        }
 
         const existingRoom = rooms.value.find(
             (r) =>
                 r.participants.every((p) => normalizedParticipants.includes(p)) &&
                 normalizedParticipants.every((p) => r.participants.includes(p)) &&
-                r.relatedJobId !== undefined &&
-                context.relatedJobId !== undefined &&
-                r.relatedJobId === context.relatedJobId
+                (
+                    (r.relatedApplicationId && context.relatedApplicationId && r.relatedApplicationId === context.relatedApplicationId) ||
+                    (r.relatedProposalId && context.relatedProposalId && r.relatedProposalId === context.relatedProposalId) ||
+                    (r.relatedJobId && context.relatedJobId && r.relatedJobId === context.relatedJobId) ||
+                    (!r.relatedApplicationId && !r.relatedProposalId && !r.relatedJobId &&
+                        !context.relatedApplicationId && !context.relatedProposalId && !context.relatedJobId)
+                )
         );
         if (existingRoom) return existingRoom.id;
 
         try {
             const newRoom = await apiCreateRoom({
                 participants: normalizedParticipants,
-                participantNames: names,
+                participantNames: normalizedNames,
                 relatedJobId: context.relatedJobId,
                 relatedApplicationId: context.relatedApplicationId,
                 relatedProposalId: context.relatedProposalId
             });
-            rooms.value.unshift(newRoom);
+            rooms.value = [newRoom, ...rooms.value.filter((room) => room.id !== newRoom.id)];
             messages.value[newRoom.id] = [];
             if (stompClient && stompClient.connected) {
                 subscribeToRoom(newRoom.id);
@@ -704,7 +825,9 @@ export const useChatStore = defineStore('chat', () => {
         isRoomReadOnly,
         updateRoomContract,
         chatAlerts,
-        dismissAlert
+        dismissAlert,
+        getParticipantName,
+        getOtherParticipantName
     };
 });
 

--- a/freebridgefe/src/stores/contractStore.ts
+++ b/freebridgefe/src/stores/contractStore.ts
@@ -115,10 +115,14 @@ export const useContractStore = defineStore('contract', () => {
     const contracts = ref<ContractWithDetails[]>([]);
     const employerSettlements = ref<EmployerSettlement[]>([]);
     const freelancerSettlements = ref<FreelancerSettlement[]>([]);
+    const isContractsLoading = ref(false);
+    const hasFetchedContracts = ref(false);
     const isSettlementLoading = ref(false);
     const employerSettlementSummary = ref<EmployerSettlementSummary | null>(null);
     const freelancerSettlementSummary = ref<FreelancerSettlementSummary | null>(null);
     const employerNextSettlement = ref<EmployerSettlementItem | null>(null);
+    let fetchContractsPromise: Promise<void> | null = null;
+    let fetchContractsPromiseKey = '';
 
     const contractsWithDetails = computed<ContractWithDetails[]>(() => contracts.value);
 
@@ -148,72 +152,130 @@ export const useContractStore = defineStore('contract', () => {
         });
     });
 
+    function findContractByAnyId(contractId: number | string | null | undefined) {
+        const parsedContractId = Number(contractId);
+        if (!Number.isFinite(parsedContractId) || parsedContractId <= 0) return null;
+        return (
+            contracts.value.find(
+                (contract) => contract.id === parsedContractId || contract.contractId === parsedContractId
+            ) || null
+        );
+    }
+
+    function findContractByParticipants(employerId: number, freelancerId: number) {
+        if (!Number.isFinite(employerId) || !Number.isFinite(freelancerId)) return null;
+
+        const matches = contracts.value.filter(
+            (contract) =>
+                Number(contract.employerId) === employerId && Number(contract.freelancerId) === freelancerId
+        );
+
+        if (matches.length === 1) return matches[0];
+
+        const activeMatches = matches.filter((contract) =>
+            ['WAITING_SIGNATURE', 'IN_PROGRESS'].includes(contract.status)
+        );
+
+        if (activeMatches.length === 1) return activeMatches[0];
+        return null;
+    }
+
     async function fetchContracts(params?: ContractListParams) {
-        const data = await listContracts(params);
-        const items = (data.items || []) as ContractWithDetails[];
-        contracts.value = items;
+        const requestKey = JSON.stringify(params ?? {});
+        if (fetchContractsPromise && fetchContractsPromiseKey === requestKey) {
+            return fetchContractsPromise;
+        }
 
-        const placeholderPattern = /(user|사용자)\s*#\s*\d+/i;
-        const numericOnlyPattern = /^\s*#?\d+\s*$/;
-        const needsName = (name?: string | null) => {
-            if (!name) return true;
-            const trimmed = name.trim();
-            return (
-                trimmed.length === 0 ||
-                trimmed === 'Unknown' ||
-                placeholderPattern.test(trimmed) ||
-                numericOnlyPattern.test(trimmed)
-            );
-        };
+        const request = (async () => {
+            isContractsLoading.value = true;
+            try {
+                const data = await listContracts(params);
+                const items = (data.items || []) as ContractWithDetails[];
+                contracts.value = items;
+                hasFetchedContracts.value = true;
 
-        const collectMissingIds = (getter: (c: ContractWithDetails) => number, nameGetter: (c: ContractWithDetails) => string | undefined | null) =>
-            Array.from(
-                new Set(
-                    items
-                        .filter((c) => needsName(nameGetter(c)))
-                        .map((c) => Number(getter(c)))
-                        .filter((id) => Number.isFinite(id) && id > 0)
-                )
-            );
+                const placeholderPattern = /(user|사용자)\s*#\s*\d+/i;
+                const numericOnlyPattern = /^\s*#?\d+\s*$/;
+                const needsName = (name?: string | null) => {
+                    if (!name) return true;
+                    const trimmed = name.trim();
+                    return (
+                        trimmed.length === 0 ||
+                        trimmed === 'Unknown' ||
+                        placeholderPattern.test(trimmed) ||
+                        numericOnlyPattern.test(trimmed)
+                    );
+                };
 
-        const missingFreelancerIds = collectMissingIds((c) => c.freelancerId, (c) => c.freelancerName);
-        const missingEmployerIds = collectMissingIds((c) => c.employerId, (c) => c.employerName);
-        const missingIds = Array.from(new Set([...missingFreelancerIds, ...missingEmployerIds]));
+                const collectMissingIds = (
+                    getter: (c: ContractWithDetails) => number,
+                    nameGetter: (c: ContractWithDetails) => string | undefined | null
+                ) =>
+                    Array.from(
+                        new Set(
+                            items
+                                .filter((c) => needsName(nameGetter(c)))
+                                .map((c) => Number(getter(c)))
+                                .filter((id) => Number.isFinite(id) && id > 0)
+                        )
+                    );
 
-        if (missingIds.length === 0) return;
+                const missingFreelancerIds = collectMissingIds((c) => c.freelancerId, (c) => c.freelancerName);
+                const missingEmployerIds = collectMissingIds((c) => c.employerId, (c) => c.employerName);
+                const missingIds = Array.from(new Set([...missingFreelancerIds, ...missingEmployerIds]));
 
-        const results = await Promise.allSettled(missingIds.map((id) => getUserById(id)));
-        const idToName = new Map<number, string>();
+                if (missingIds.length === 0) return;
 
-        results.forEach((result, index) => {
-            if (result.status !== 'fulfilled') return;
-            const user = result.value as Record<string, any>;
-            const payload = user?.data ?? user;
-            const name =
-                payload?.name ||
-                payload?.fullName ||
-                payload?.username ||
-                payload?.nickname ||
-                payload?.userName ||
-                payload?.memberName ||
-                payload?.realName;
-            if (name) {
-                idToName.set(missingIds[index], String(name));
+                const results = await Promise.allSettled(missingIds.map((id) => getUserById(id)));
+                const idToName = new Map<number, string>();
+
+                results.forEach((result, index) => {
+                    if (result.status !== 'fulfilled') return;
+                    const user = result.value as Record<string, any>;
+                    const payload = user?.data ?? user;
+                    const name =
+                        payload?.name ||
+                        payload?.fullName ||
+                        payload?.username ||
+                        payload?.nickname ||
+                        payload?.userName ||
+                        payload?.memberName ||
+                        payload?.realName;
+                    if (name) {
+                        idToName.set(missingIds[index], String(name));
+                    }
+                });
+
+                if (idToName.size === 0) return;
+
+                contracts.value = items.map((contract) => {
+                    const resolvedFreelancer = idToName.get(Number(contract.freelancerId));
+                    const resolvedEmployer = idToName.get(Number(contract.employerId));
+                    if (!resolvedFreelancer && !resolvedEmployer) return contract;
+                    return {
+                        ...contract,
+                        freelancerName: resolvedFreelancer ?? contract.freelancerName,
+                        employerName: resolvedEmployer ?? contract.employerName,
+                    };
+                });
+            } finally {
+                isContractsLoading.value = false;
+                if (fetchContractsPromise === request) {
+                    fetchContractsPromise = null;
+                    fetchContractsPromiseKey = '';
+                }
             }
-        });
+        })();
 
-        if (idToName.size === 0) return;
+        fetchContractsPromise = request;
+        fetchContractsPromiseKey = requestKey;
+        return request;
+    }
 
-        contracts.value = items.map((contract) => {
-            const resolvedFreelancer = idToName.get(Number(contract.freelancerId));
-            const resolvedEmployer = idToName.get(Number(contract.employerId));
-            if (!resolvedFreelancer && !resolvedEmployer) return contract;
-            return {
-                ...contract,
-                freelancerName: resolvedFreelancer ?? contract.freelancerName,
-                employerName: resolvedEmployer ?? contract.employerName,
-            };
-        });
+    async function ensureContractsLoaded() {
+        if (hasFetchedContracts.value && contracts.value.length > 0) return;
+        if (hasFetchedContracts.value && !isContractsLoading.value) return;
+        await fetchContracts();
     }
 
     async function fetchEmployerSettlements(params?: {
@@ -310,6 +372,8 @@ export const useContractStore = defineStore('contract', () => {
         contracts,
         employerSettlements,
         freelancerSettlements,
+        isContractsLoading,
+        hasFetchedContracts,
         isSettlementLoading,
         employerSettlementSummary,
         freelancerSettlementSummary,
@@ -317,7 +381,10 @@ export const useContractStore = defineStore('contract', () => {
         contractsWithDetails,
         employerSettlementsWithDetails,
         freelancerSettlementsWithDetails,
+        findContractByAnyId,
+        findContractByParticipants,
         fetchContracts,
+        ensureContractsLoaded,
         fetchEmployerSettlements,
         fetchFreelancerSettlements,
         fetchEmployerSettlementSummary,

--- a/freebridgefe/src/stores/contractStore.ts
+++ b/freebridgefe/src/stores/contractStore.ts
@@ -111,6 +111,16 @@ const getPagedItems = <T>(payload: { content?: T[]; items?: T[] } | undefined | 
     return [];
 };
 
+const isDefaultContractListRequest = (params?: ContractListParams) => {
+    if (!params) return true;
+
+    return Object.values(params).every((value) => {
+        if (value === undefined || value === null || value === '') return true;
+        if (Array.isArray(value)) return value.length === 0;
+        return false;
+    });
+};
+
 export const useContractStore = defineStore('contract', () => {
     const contracts = ref<ContractWithDetails[]>([]);
     const employerSettlements = ref<EmployerSettlement[]>([]);
@@ -182,6 +192,7 @@ export const useContractStore = defineStore('contract', () => {
 
     async function fetchContracts(params?: ContractListParams) {
         const requestKey = JSON.stringify(params ?? {});
+        const isDefaultRequest = isDefaultContractListRequest(params);
         if (fetchContractsPromise && fetchContractsPromiseKey === requestKey) {
             return fetchContractsPromise;
         }
@@ -192,7 +203,9 @@ export const useContractStore = defineStore('contract', () => {
                 const data = await listContracts(params);
                 const items = (data.items || []) as ContractWithDetails[];
                 contracts.value = items;
-                hasFetchedContracts.value = true;
+                if (isDefaultRequest) {
+                    hasFetchedContracts.value = true;
+                }
 
                 const placeholderPattern = /(user|사용자)\s*#\s*\d+/i;
                 const numericOnlyPattern = /^\s*#?\d+\s*$/;

--- a/freebridgefe/src/stores/freelancerStore.ts
+++ b/freebridgefe/src/stores/freelancerStore.ts
@@ -275,10 +275,10 @@ export const useFreelancerStore = defineStore("freelancer", () => {
 
     if (status === "ACCEPTED") {
       const chatStore = useChatStore();
-      const rawEmployerId = proposals.value[index].employerId;
-      const rawFreelancerId = proposals.value[index].freelancerId;
-      const employerId = `e${rawEmployerId}`;
-      const freelancerId = `f${rawFreelancerId}`;
+      const rawEmployerId = String(proposals.value[index].employerId);
+      const rawFreelancerId = String(proposals.value[index].freelancerId);
+      const employerId = rawEmployerId.startsWith("e") ? rawEmployerId : `e${rawEmployerId}`;
+      const freelancerId = rawFreelancerId.startsWith("f") ? rawFreelancerId : `f${rawFreelancerId}`;
       const jobId = proposals.value[index].jobId; // Capture possibly undefined jobId
 
       const context: any = {

--- a/freebridgefe/src/views/employer/Contracts/ContractsView.vue
+++ b/freebridgefe/src/views/employer/Contracts/ContractsView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { ref, computed, onMounted, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import {
     FileText,
     Calendar,
@@ -18,6 +18,7 @@ import { useAuthStore } from '@/stores/authStore';
 import { useContractStore, type ContractWithDetails } from '@/stores/contractStore';
 import ContractDetailModal from './components/ContractDetailModal.vue';
 
+const route = useRoute();
 const router = useRouter();
 const authStore = useAuthStore();
 const contractStore = useContractStore();
@@ -141,9 +142,37 @@ const resetFilters = () => {
     isDropdownOpen.value = false;
 };
 
-onMounted(() => {
-    contractStore.fetchContracts();
+const getNumericQueryValue = (value: unknown) => {
+    const rawValue = Array.isArray(value) ? value[0] : value;
+    const parsedValue = Number(rawValue);
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+};
+
+async function syncSelectedContractFromRoute() {
+    const routeContractId = getNumericQueryValue(route.query.contractId);
+    if (!routeContractId) return;
+
+    if (!contractStore.findContractByAnyId(routeContractId)) {
+        await contractStore.fetchContracts();
+    }
+
+    const matchedContract = contractStore.findContractByAnyId(routeContractId);
+    if (matchedContract) {
+        selectedContract.value = matchedContract;
+    }
+}
+
+onMounted(async () => {
+    await contractStore.fetchContracts();
+    await syncSelectedContractFromRoute();
 });
+
+watch(
+    () => route.query.contractId,
+    () => {
+        void syncSelectedContractFromRoute();
+    }
+);
 </script>
 
 <template>

--- a/freebridgefe/src/views/employer/Contracts/CreateContractView.vue
+++ b/freebridgefe/src/views/employer/Contracts/CreateContractView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
+import { ref, computed, onMounted, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import {
     FilePlus,
     Building2,
@@ -22,6 +22,7 @@ import {
 } from 'lucide-vue-next';
 import { useAuthStore } from '@/stores/authStore';
 import { useContractStore, type ContractWithDetails } from '@/stores/contractStore';
+import { useFreelancerStore } from '@/stores/freelancerStore';
 import { createContract, getEmployerRecruitmentProjects, getMatchedFreelancers, type EmployerProject, type MatchedFreelancer } from '@/api/contractApi';
 import { getEmployerProfile } from '@/api/MyPage/employer';
 import SignaturePadModal from './components/SignaturePadModal.vue';
@@ -29,9 +30,11 @@ import ContractPreview from '@/components/contract/ContractPreview.vue';
 
 type CreateContractState = 'form' | 'preview' | 'signing' | 'success';
 
+const route = useRoute();
 const router = useRouter();
 const authStore = useAuthStore();
 const contractStore = useContractStore();
+const freelancerStore = useFreelancerStore();
 
 const state = ref<CreateContractState>('form');
 const currentStep = ref(1);
@@ -52,6 +55,37 @@ function extractArray<T>(data: any): T[] {
     if (Array.isArray(data)) return data;
     if (data && Array.isArray(data.content)) return data.content;
     return [];
+}
+
+function getNumericQueryValue(value: unknown) {
+    const rawValue = Array.isArray(value) ? value[0] : value;
+    const parsedValue = Number(rawValue);
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+}
+
+function getStringQueryValue(value: unknown) {
+    const rawValue = Array.isArray(value) ? value[0] : value;
+    if (rawValue === undefined || rawValue === null) return null;
+    const normalizedValue = String(rawValue).trim();
+    return normalizedValue.length > 0 ? normalizedValue : null;
+}
+
+function formatDateInput(value?: Date | string | null) {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+}
+
+function findMatchingProjectByJobId(jobId: number | null) {
+    if (!jobId) return null;
+    return projectOptions.value.find((project) =>
+        Number(project.projectId) === jobId || Number(project.jobPostingId) === jobId
+    ) || null;
 }
 
 async function loadMatchedFreelancers(id: number) {
@@ -115,6 +149,7 @@ onMounted(async () => {
     }
 
     isLoadingProjects.value = false;
+    await applyRouteContextToCreateForm();
 });
 
 // Step 1: Basic Info
@@ -295,9 +330,85 @@ const handleReset = () => {
     state.value = 'form';
 };
 
+async function applyRouteContextToCreateForm() {
+    const routeJobId = getNumericQueryValue(route.query.jobId);
+    const routeProposalId = getStringQueryValue(route.query.proposalId);
+    const routeContractId = getNumericQueryValue(route.query.contractId);
+
+    let sourceContract: ContractWithDetails | null = null;
+    if (routeContractId) {
+        await contractStore.ensureContractsLoaded().catch(() => undefined);
+        sourceContract = contractStore.findContractByAnyId(routeContractId);
+    }
+
+    let sourceProposal = null;
+    if (routeProposalId) {
+        if (!freelancerStore.proposals.some((proposal) => proposal.id === routeProposalId)) {
+            await freelancerStore.fetchEmployerProposals().catch(() => undefined);
+        }
+        sourceProposal = freelancerStore.proposals.find((proposal) => proposal.id === routeProposalId) || null;
+    }
+
+    const fallbackJobId =
+        routeJobId ??
+        (sourceProposal?.jobId ? Number(sourceProposal.jobId) : null) ??
+        (sourceContract?.projectId ? Number(sourceContract.projectId) : null);
+
+    const matchedProject = findMatchingProjectByJobId(fallbackJobId);
+    if (matchedProject && (selectedProjectId.value !== matchedProject.projectId || freelancerOptions.value.length === 0)) {
+        await onProjectSelect(matchedProject.projectId);
+    }
+
+    const routeFreelancerId =
+        sourceProposal?.freelancerId ? Number(sourceProposal.freelancerId) : sourceContract?.freelancerId ?? null;
+    if (routeFreelancerId && Number.isFinite(routeFreelancerId)) {
+        selectedFreelancerId.value = routeFreelancerId;
+    }
+
+    const fallbackProjectName =
+        sourceContract?.projectName ||
+        matchedProject?.projectName ||
+        (sourceProposal?.message ? sourceProposal.message.slice(0, 24) : '');
+    if (fallbackProjectName) {
+        projectName.value = fallbackProjectName;
+    }
+
+    const fallbackJobDescription =
+        sourceContract?.jobDescription ||
+        sourceProposal?.message ||
+        jobDescription.value;
+    if (fallbackJobDescription) {
+        jobDescription.value = fallbackJobDescription;
+    }
+
+    if (sourceContract) {
+        startDate.value = formatDateInput(sourceContract.startDate);
+        endDate.value = formatDateInput(sourceContract.endDate);
+        budget.value = String(sourceContract.budget ?? '');
+        paymentDay.value = sourceContract.paymentDay ?? 25;
+    }
+}
+
 const navigateToContracts = () => {
-    router.push('/employer/contracts');
+    const query: Record<string, string> = {};
+    const routeRoomId = getStringQueryValue(route.query.roomId);
+
+    if (routeRoomId) {
+        query.roomId = routeRoomId;
+    }
+    if (createdContract.value?.contractId) {
+        query.contractId = String(createdContract.value.contractId);
+    }
+
+    router.push({ name: 'employer.contracts', query });
 };
+
+watch(
+    () => [route.query.jobId, route.query.proposalId, route.query.contractId],
+    () => {
+        void applyRouteContextToCreateForm();
+    }
+);
 </script>
 
 <template>

--- a/freebridgefe/src/views/freelancer/Contracts/ContractList.vue
+++ b/freebridgefe/src/views/freelancer/Contracts/ContractList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, onMounted, watch } from 'vue';
+import { useRoute } from 'vue-router';
 import {
     FileText,
     Calendar,
@@ -21,6 +22,7 @@ import { signContract } from '@/api/contractApi';
 
 const authStore = useAuthStore();
 const contractStore = useContractStore();
+const route = useRoute();
 
 const selectedContract = ref<ContractWithDetails | null>(null);
 const signingContract = ref<ContractWithDetails | null>(null);
@@ -167,9 +169,37 @@ const openSignModal = (contract: ContractWithDetails) => {
     signingContract.value = contract;
 };
 
-onMounted(() => {
-    contractStore.fetchContracts();
+const getNumericQueryValue = (value: unknown) => {
+    const rawValue = Array.isArray(value) ? value[0] : value;
+    const parsedValue = Number(rawValue);
+    return Number.isFinite(parsedValue) ? parsedValue : null;
+};
+
+async function syncSelectedContractFromRoute() {
+    const routeContractId = getNumericQueryValue(route.query.contractId);
+    if (!routeContractId) return;
+
+    if (!contractStore.findContractByAnyId(routeContractId)) {
+        await contractStore.fetchContracts();
+    }
+
+    const matchedContract = contractStore.findContractByAnyId(routeContractId);
+    if (matchedContract) {
+        selectedContract.value = matchedContract;
+    }
+}
+
+onMounted(async () => {
+    await contractStore.fetchContracts();
+    await syncSelectedContractFromRoute();
 });
+
+watch(
+    () => route.query.contractId,
+    () => {
+        void syncSelectedContractFromRoute();
+    }
+);
 </script>
 
 <template>

--- a/freebridgefe/src/views/freelancer/Contracts/ContractList.vue
+++ b/freebridgefe/src/views/freelancer/Contracts/ContractList.vue
@@ -180,7 +180,11 @@ async function syncSelectedContractFromRoute() {
     if (!routeContractId) return;
 
     if (!contractStore.findContractByAnyId(routeContractId)) {
-        await contractStore.fetchContracts();
+        try {
+            await contractStore.fetchContracts();
+        } catch (error) {
+            console.error('계약 목록 재조회 중 오류가 발생했습니다:', error);
+        }
     }
 
     const matchedContract = contractStore.findContractByAnyId(routeContractId);


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
 매칭 후 한쪽에서만 방이 안 뜨던 건 방 목록을 레이아웃 최초 마운트 때만 가져오던 흐름도 원인. 
그래서 PlatformLayout.vue (line 91)에서 채팅 진입 시, 창 포커스 복귀 시, 탭 가시화 시 방 목록을 다시 동기화
## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 채팅 정보 패널에 상대방 동적 요약 추가(프리랜서 소개·주요 기술·회사/제안 설명 등)
  * 채팅 및 계약 UI에서 계약 화면으로 이동하는 통합 내비게이션 및 라우트 기반 사전선택 지원

* **개선 사항**
  * 참가자 이름/ID 일관성 강화로 프로필·네비게이션 정확도 향상
  * 채팅 방·계약 로드/갱신 로직 개선(포커스/가시성, 중복 요청 방지, 에러 처리)
  * 계약 탭 UI를 상태 중심으로 간소화하고 로딩/빈 상태 안내 개선

* **버그 수정**
  * 이름 미확인 시 일관된 기본값("알 수 없음") 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->