### PR TITLE
Hfp 108  fix: 프리랜서 마이페이지 리뷰 요약 API 호출 보장

### DIFF
--- a/freebridgefe/src/views/employer/Review/ReviewList.vue
+++ b/freebridgefe/src/views/employer/Review/ReviewList.vue
@@ -177,12 +177,9 @@ onMounted(() => {
             아직 작성한 후기가 없습니다.
           </div>
           <div
-            v-for="(review, index) in employerToFreelancerReviews"
+            v-for="review in employerToFreelancerReviews"
             :key="review.id"
             class="bg-white/5 border border-white/10 rounded-2xl p-6"
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
               <div>
@@ -322,12 +319,9 @@ onMounted(() => {
             아직 프리랜서가 남긴 후기가 없습니다.
           </div>
           <div
-            v-for="(review, index) in freelancerToEmployerReviews"
+            v-for="review in freelancerToEmployerReviews"
             :key="review.id"
             class="bg-white/5 border border-white/10 rounded-2xl p-6"
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
               <div>

--- a/freebridgefe/src/views/freelancer/Applications/MyApplications.vue
+++ b/freebridgefe/src/views/freelancer/Applications/MyApplications.vue
@@ -337,7 +337,7 @@ const handleRejectProposal = async (proposalId: string) => {
           </div>
 
           <div
-            v-for="(proposal, index) in receivedProposals"
+            v-for="proposal in receivedProposals"
             :key="proposal.id"
             class="bg-white/5 border rounded-2xl p-6"
             :class="
@@ -347,9 +347,6 @@ const handleRejectProposal = async (proposalId: string) => {
                   ? 'border-red-500/30'
                   : 'border-white/10'
             "
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col lg:flex-row items-start justify-between gap-6 mb-5">
               <div class="flex-1">
@@ -453,12 +450,9 @@ const handleRejectProposal = async (proposalId: string) => {
           </div>
 
           <div
-            v-for="(app, index) in myApplications"
+            v-for="app in myApplications"
             :key="app.id"
             class="bg-white/5 border border-white/10 rounded-2xl p-6"
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col lg:flex-row items-start justify-between gap-6 mb-6">
               <div class="flex-1">

--- a/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
@@ -108,9 +108,17 @@ const handleProfileUpdate = (updatedData: FreelancerProfileDashboard) => {
     activeTab.value = 'dashboard';
 };
 
+const latestDashboardRequestId = ref(0);
+
 const loadFreelancerDashboard = async (userId?: string | number) => {
+    const requestId = ++latestDashboardRequestId.value;
+    const isLatestRequest = () => requestId === latestDashboardRequestId.value;
+
     if (!userId) {
         const data = await getFreelancerProfile('guest');
+        if (!isLatestRequest()) {
+            return;
+        }
         profile.value = data;
         return;
     }
@@ -121,6 +129,9 @@ const loadFreelancerDashboard = async (userId?: string | number) => {
     ]);
 
     if (profileResult.status === 'fulfilled') {
+        if (!isLatestRequest()) {
+            return;
+        }
         profile.value = profileResult.value;
 
         if (currentUser.value?.name) profile.value.name = currentUser.value.name;
@@ -132,6 +143,9 @@ const loadFreelancerDashboard = async (userId?: string | number) => {
     }
 
     if (statsResult.status === 'fulfilled') {
+        if (!isLatestRequest()) {
+            return;
+        }
         profile.value.statInteresting = statsResult.value.inProgressProjects ?? 0;
         profile.value.statCompleted = statsResult.value.completedProjects ?? 0;
     } else {
@@ -140,9 +154,15 @@ const loadFreelancerDashboard = async (userId?: string | number) => {
 
     try {
         const summary = await getFreelancerReviewSummary();
+        if (!isLatestRequest()) {
+            return;
+        }
         profile.value.averageRating = summary.averageRate ?? 0;
         profile.value.topPercentile = summary.topPercentile ?? 0;
     } catch (error) {
+        if (!isLatestRequest()) {
+            return;
+        }
         console.error('Failed to load review summary:', error);
     }
 
@@ -152,6 +172,9 @@ const loadFreelancerDashboard = async (userId?: string | number) => {
     ]);
 
     if (positivityResult.status === 'fulfilled' || strengthWeaknessResult.status === 'fulfilled') {
+        if (!isLatestRequest()) {
+            return;
+        }
         profile.value.aiSummary = {
             positivityScore:
                 positivityResult.status === 'fulfilled'
@@ -175,8 +198,8 @@ const loadFreelancerDashboard = async (userId?: string | number) => {
 
 watch(
     () => currentUser.value?.id,
-    async (userId) => {
-        await loadFreelancerDashboard(userId);
+    (userId) => {
+        void loadFreelancerDashboard(userId);
     },
     { immediate: true }
 );

--- a/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/MyPageFreelancer.vue
@@ -1,5 +1,5 @@
 ﻿<script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useMotion } from '@vueuse/motion';
 import {
@@ -108,74 +108,78 @@ const handleProfileUpdate = (updatedData: FreelancerProfileDashboard) => {
     activeTab.value = 'dashboard';
 };
 
-onMounted(async () => {
-    if (currentUser.value?.id) {
-        try {
-            const data = await getFreelancerProfile(currentUser.value.id);
-            profile.value = data;
-
-            // authStore 이름/스킬 우선 반영
-            if (currentUser.value.name) profile.value.name = currentUser.value.name;
-            if (currentUser.value.skills && currentUser.value.skills.length > 0) {
-                profile.value.skills = currentUser.value.skills;
-            }
-
-            try {
-                const stats = await getFreelancerProjectStats();
-                profile.value.statInteresting = stats.inProgressProjects ?? 0;
-                profile.value.statCompleted = stats.completedProjects ?? 0;
-            } catch (statsError) {
-                console.error('Failed to load project stats:', statsError);
-            }
-
-            try {
-                const [summaryResult, positivityResult, strengthWeaknessResult] = await Promise.allSettled([
-                    getFreelancerReviewSummary(),
-                    getFreelancerAiPositivityIndex(),
-                    getFreelancerStrengthWeakness(),
-                ]);
-
-                if (summaryResult.status === 'fulfilled') {
-                    const summary = summaryResult.value;
-                    profile.value.averageRating = summary.averageRate ?? 0;
-                    profile.value.topPercentile = summary.topPercentile ?? 0;
-                }
-
-                if (
-                    positivityResult.status === 'fulfilled' ||
-                    strengthWeaknessResult.status === 'fulfilled'
-                ) {
-                    profile.value.aiSummary = {
-                        positivityScore:
-                            positivityResult.status === 'fulfilled'
-                                ? positivityResult.value.positivityScore ?? 0
-                                : 0,
-                        grade:
-                            positivityResult.status === 'fulfilled'
-                                ? positivityResult.value.grade ?? ''
-                                : '',
-                        strengths:
-                            strengthWeaknessResult.status === 'fulfilled'
-                                ? strengthWeaknessResult.value.strengths ?? []
-                                : [],
-                        weaknesses:
-                            strengthWeaknessResult.status === 'fulfilled'
-                                ? strengthWeaknessResult.value.weaknesses ?? []
-                                : [],
-                    };
-                }
-            } catch (reviewError) {
-                console.error('Failed to load review summary/ai data:', reviewError);
-            }
-        } catch (error) {
-            console.error('Failed to load profile:', error);
-        }
-    } else {
-        // 로그인 정보가 없을 때의 폴백 처리
+const loadFreelancerDashboard = async (userId?: string | number) => {
+    if (!userId) {
         const data = await getFreelancerProfile('guest');
         profile.value = data;
+        return;
     }
-});
+
+    const [profileResult, statsResult] = await Promise.allSettled([
+        getFreelancerProfile(String(userId)),
+        getFreelancerProjectStats(),
+    ]);
+
+    if (profileResult.status === 'fulfilled') {
+        profile.value = profileResult.value;
+
+        if (currentUser.value?.name) profile.value.name = currentUser.value.name;
+        if (currentUser.value?.skills && currentUser.value.skills.length > 0) {
+            profile.value.skills = currentUser.value.skills;
+        }
+    } else {
+        console.error('Failed to load profile:', profileResult.reason);
+    }
+
+    if (statsResult.status === 'fulfilled') {
+        profile.value.statInteresting = statsResult.value.inProgressProjects ?? 0;
+        profile.value.statCompleted = statsResult.value.completedProjects ?? 0;
+    } else {
+        console.error('Failed to load project stats:', statsResult.reason);
+    }
+
+    try {
+        const summary = await getFreelancerReviewSummary();
+        profile.value.averageRating = summary.averageRate ?? 0;
+        profile.value.topPercentile = summary.topPercentile ?? 0;
+    } catch (error) {
+        console.error('Failed to load review summary:', error);
+    }
+
+    const [positivityResult, strengthWeaknessResult] = await Promise.allSettled([
+        getFreelancerAiPositivityIndex(),
+        getFreelancerStrengthWeakness(),
+    ]);
+
+    if (positivityResult.status === 'fulfilled' || strengthWeaknessResult.status === 'fulfilled') {
+        profile.value.aiSummary = {
+            positivityScore:
+                positivityResult.status === 'fulfilled'
+                    ? positivityResult.value.positivityScore ?? 0
+                    : 0,
+            grade:
+                positivityResult.status === 'fulfilled'
+                    ? positivityResult.value.grade ?? ''
+                    : '',
+            strengths:
+                strengthWeaknessResult.status === 'fulfilled'
+                    ? strengthWeaknessResult.value.strengths ?? []
+                    : [],
+            weaknesses:
+                strengthWeaknessResult.status === 'fulfilled'
+                    ? strengthWeaknessResult.value.weaknesses ?? []
+                    : [],
+        };
+    }
+};
+
+watch(
+    () => currentUser.value?.id,
+    async (userId) => {
+        await loadFreelancerDashboard(userId);
+    },
+    { immediate: true }
+);
 
 const menuItems = [
     { id: 'dashboard', label: '프로필 관리', icon: User, action: () => activeTab.value = 'dashboard' },

--- a/freebridgefe/src/views/freelancer/Review/ReviewList.vue
+++ b/freebridgefe/src/views/freelancer/Review/ReviewList.vue
@@ -174,12 +174,9 @@ onMounted(() => {
             아직 작성한 후기가 없습니다.
           </div>
           <div
-            v-for="(review, index) in freelancerToEmployerReviews"
+            v-for="review in freelancerToEmployerReviews"
             :key="review.id"
             class="bg-white/5 border border-white/10 rounded-2xl p-6"
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
               <div>
@@ -319,12 +316,9 @@ onMounted(() => {
             아직 기업이 남긴 후기가 없습니다.
           </div>
           <div
-            v-for="(review, index) in employerToFreelancerReviews"
+            v-for="review in employerToFreelancerReviews"
             :key="review.id"
             class="bg-white/5 border border-white/10 rounded-2xl p-6"
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
               <div>


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
프리랜서 마이페이지 진입 시 리뷰 요약 API가 누락되지 않도록 호출 흐름을 정리해, 백엔드의 리뷰 요약 Redis 캐시가 안정적으로 생성되도록 수정했습니다.

## ✅ Changes
- 프리랜서 마이페이지 데이터 로딩 흐름을 정리
- 리뷰 요약 API를 프로필/통계 조회와 분리해 독립적으로 호출하도록 수정
- 사용자 정보가 준비되는 시점에 맞춰 마이페이지 API가 호출되도록 로딩 타이밍 보완
- AI 분석 API 호출과 별개로 리뷰 요약 API가 먼저 실행되도록 순서 정리
- `npm run build`로 프론트 빌드 검증 완료

## 📸 스크린샷 (선택)
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 이번 PR은 화면 변경보다 마이페이지 초기 데이터 호출 안정화에 초점이 있습니다.
- 백엔드에서 리뷰 요약 Redis는 `GET /api/freelancer/mypage/reviews/summary` 호출 시 생성되므로, 이번 수정으로 마이페이지 진입 시 캐시 생성이 보장됩니다.
- AI 분석 서버가 내려가 있어도 리뷰 요약 API 호출 자체는 독립적으로 동작하도록 분리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 리뷰 목록 및 지원 현황 페이지의 애니메이션 제거로 렌더링 안정성 개선

* **Refactor**
  * 프리랜서 대시보드 데이터 로딩 방식 최적화로 사용자 정보 변경 시 더 빠른 반응성 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->