### PR TITLE
HFP-109 fix: 프로필찾기 제안 시 freelancer PK 대신 userId 전달

### DIFF
--- a/freebridgefe/src/views/employer/Freelancers/FreelancerSearchView.vue
+++ b/freebridgefe/src/views/employer/Freelancers/FreelancerSearchView.vue
@@ -73,7 +73,7 @@ const isFavorite = (id: number) => favoritesStore.favoriteIds.includes(String(id
 const toggleFavorite = (id: number) => favoritesStore.toggleFavorite(String(id));
 
 const toProposalFreelancer = (freelancer: EmployerFreelancerSearchItem): User => ({
-  id: String(freelancer.freelancerId),
+  id: String(freelancer.userId),
   role: 'FREELANCER',
   name: freelancer.name,
   email: 'hidden@example.com',


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
프로필찾기 페이지에서 프리랜서에게 제안하기를 눌렀을 때 잘못된 ID가 전달되던 문제를 수정했습니다.

## ✅ Changes
- 프리랜서 검색 응답에서 내려오는 `userId`와 `freelancerId` 사용 위치를 점검
- 프로필찾기 페이지의 제안하기 동작이 `freelancer` 테이블 PK가 아닌 `freelancer.user_id`를 전달하도록 수정
- 기존 즐겨찾기/목록 식별용 `freelancerId` 사용은 유지하고, 제안 전송 대상 ID만 분리 적용

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 백엔드 검색 응답에는 `freelancerId`와 `userId`가 모두 포함되어 있었고, 프론트에서 제안 대상 ID 매핑만 잘못 사용하고 있었습니다.
- 이번 수정은 프로필찾기 페이지의 제안하기 흐름에 한정됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

* 프리랜서 검색 결과에서 프리랜서 식별 정보가 올바르게 처리되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->