### PR TITLE
Hfp 108 fix 프론트 목록 노출 버그 수정

### DIFF
--- a/freebridgefe/src/views/employer/Applications/ApplicationList.vue
+++ b/freebridgefe/src/views/employer/Applications/ApplicationList.vue
@@ -49,7 +49,6 @@ onMounted(async () => {
 
 const currentUser = computed(() => authStore.user);
 const myJobs = computed(() => jobStore.myJobs);
-const currentEmployerName = computed(() => currentUser.value?.companyName || currentUser.value?.name || '');
 
 const sortByCreatedAtDesc = <T extends { id: string; createdAt: Date | string }>(items: T[]) => {
   const latestById = new Map<string, T>();
@@ -75,13 +74,7 @@ const myReceivedApplications = computed(() =>
 const mySentProposals = computed(() => {
   if (!currentUser.value) return [];
 
-  return sortByCreatedAtDesc(
-    freelancerStore.proposals.filter((proposal) => {
-      const idMatched = String(proposal.employerId) === String(currentUser.value?.id);
-      const nameMatched = proposal.employerName === currentEmployerName.value;
-      return idMatched || nameMatched;
-    }),
-  );
+  return sortByCreatedAtDesc(freelancerStore.proposals);
 });
 
 const statusConfig: Record<ApplicationStatus, { icon: any; label: string; gradient: string }> = {

--- a/freebridgefe/src/views/employer/Review/ReviewList.vue
+++ b/freebridgefe/src/views/employer/Review/ReviewList.vue
@@ -180,9 +180,6 @@ onMounted(() => {
             v-for="(review, index) in employerToFreelancerReviews"
             :key="review.id"
             class="bg-white/5 border border-white/10 rounded-2xl p-6"
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
               <div>
@@ -325,9 +322,6 @@ onMounted(() => {
             v-for="(review, index) in freelancerToEmployerReviews"
             :key="review.id"
             class="bg-white/5 border border-white/10 rounded-2xl p-6"
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
               <div>

--- a/freebridgefe/src/views/freelancer/Applications/MyApplications.vue
+++ b/freebridgefe/src/views/freelancer/Applications/MyApplications.vue
@@ -48,23 +48,14 @@ onMounted(async () => {
 
 const currentUser = computed(() => authStore.user);
 
-const isSameFreelancer = (freelancerId: string | number, freelancerName: string) => {
-  if (!currentUser.value) return false;
-  const idMatched = String(freelancerId) === String(currentUser.value.id);
-  const nameMatched = freelancerName === currentUser.value.name;
-  return idMatched || nameMatched;
-};
-
 const myApplications = computed(() => {
   if (!currentUser.value) return [];
-  return jobStore.applications.filter((app) => isSameFreelancer(app.freelancerId, app.freelancerName));
+  return jobStore.applications;
 });
 
 const receivedProposals = computed(() => {
   if (!currentUser.value) return [];
-  return freelancerStore.proposals.filter((proposal) =>
-    isSameFreelancer(proposal.freelancerId, proposal.freelancerName)
-  );
+  return freelancerStore.proposals;
 });
 
 const getJobTitle = (jobId: string) => {

--- a/freebridgefe/src/views/freelancer/Applications/MyApplications.vue
+++ b/freebridgefe/src/views/freelancer/Applications/MyApplications.vue
@@ -143,15 +143,9 @@ const handleAcceptProposal = async (proposalId: string) => {
 
 const handleRejectProposal = async (proposalId: string) => {
   if (!window.confirm('이 제안을 거절하시겠습니까?')) return;
-  const reason = window.prompt('거절 사유를 입력해 주세요. (선택)');
-  if (reason === null) return;
 
   try {
-    const updated = await freelancerStore.updateProposalStatus(
-      proposalId,
-      'REJECTED',
-      reason.trim() || undefined
-    );
+    const updated = await freelancerStore.updateProposalStatus(proposalId, 'REJECTED');
     if (!updated) {
       actionFeedback.value = { type: 'error', message: '제안 상태 변경에 실패했습니다. 다시 시도해 주세요.' };
       alert('제안 상태 변경에 실패했습니다.');

--- a/freebridgefe/src/views/freelancer/Review/ReviewList.vue
+++ b/freebridgefe/src/views/freelancer/Review/ReviewList.vue
@@ -177,9 +177,6 @@ onMounted(() => {
             v-for="(review, index) in freelancerToEmployerReviews"
             :key="review.id"
             class="bg-white/5 border border-white/10 rounded-2xl p-6"
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
               <div>
@@ -322,9 +319,6 @@ onMounted(() => {
             v-for="(review, index) in employerToFreelancerReviews"
             :key="review.id"
             class="bg-white/5 border border-white/10 rounded-2xl p-6"
-            v-motion
-            :initial="{ opacity: 0, y: 10 }"
-            :enter="{ opacity: 1, y: 0, transition: { delay: index * 50 } }"
           >
             <div class="flex flex-col md:flex-row md:items-start justify-between gap-4 mb-4">
               <div>


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
프론트 목록 화면에서 일부 데이터가 정상 조회되더라도 화면에 누락되거나 잘못된 ID로 처리되던 문제를 수정했습니다. 프로필찾기 제안 대상 ID, 지원/제안 목록의 추가 필터링, 리뷰 목록의 일부 카드 미노출 문제를 함께 정리했습니다.

## ✅ Changes
- 프로필찾기 페이지의 제안하기 동작이 `freelancer` PK가 아닌 `freelancer.userId`를 사용하도록 수정
- 프리랜서가 고용주 제안을 거절할 때 표시되던 사유 입력창 제거
- 지원/제안 목록 화면에서 프론트의 추가 사용자 필터링을 제거해 서버에서 조회된 목록이 그대로 표시되도록 수정
- 리뷰 목록에서 일부 카드가 DOM에는 존재하지만 화면에서 숨겨지던 렌더링 문제 수정
- 고용주가 프리랜서 지원서를 거절할 때의 사유 작성 기능은 기존대로 유지

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 이번 수정은 FE 표시/전달 로직 중심이며, 백엔드 응답 구조 자체는 변경하지 않았습니다.
- 지원/제안 목록은 서버가 현재 사용자 기준으로 반환한다는 전제로 프론트 재필터링을 제거했습니다.
- 리뷰 목록은 반복 카드에 적용된 애니메이션으로 인해 일부 항목이 보이지 않던 현상을 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **스타일**
  * 고용주 및 프리랜서 리뷰 목록에서 항목별 애니메이션 효과 제거

* **변경사항**
  * 제안 및 지원서 목록 필터링 로직 수정
  * 제안 거절 시 사유 입력 프롬프트 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->