### PR TITLE
HFP-109 fix: 프리랜서 후기 작성 대상 기업명 표시 로직 보완

### DIFF
--- a/freebridgefe/src/stores/reviewStore.ts
+++ b/freebridgefe/src/stores/reviewStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 import { getUserById } from '@/api/authApi';
-import { listContracts, type ContractSummaryDto } from '@/api/contractApi';
+import { getContract, listContracts, type ContractSummaryDto } from '@/api/contractApi';
 import { getEmployerProjects as getEmployerMypageProjects } from '@/api/MyPage/projectApi';
 import {
   createEmployerReview,
@@ -548,6 +548,24 @@ export const useReviewStore = defineStore('review', () => {
         listContracts({ status: ['IN_PROGRESS', 'COMPLETED'], page: 1, limit: 100 }),
         getFreelancerWrittenReviews(0, 100),
       ]);
+      const contractDetails = await Promise.allSettled(
+        (contracts.items ?? []).map(async (item) => {
+          const detail = await getContract(item.contractId || item.id);
+          return [String(item.id), detail.employerBusinessName || detail.employerName || ''] as const;
+        }),
+      );
+      const employerNames = await resolveUserDisplayNames(
+        (contracts.items ?? []).map((item) => item.employerId),
+      );
+      const employerBusinessNames = contractDetails.reduce<Record<string, string>>((acc, result) => {
+        if (result.status === 'fulfilled') {
+          const [projectId, employerBusinessName] = result.value;
+          if (employerBusinessName) {
+            acc[projectId] = employerBusinessName;
+          }
+        }
+        return acc;
+      }, {});
 
       const writtenKeys = new Set(
         (writtenResponse.content ?? []).map(
@@ -563,7 +581,11 @@ export const useReviewStore = defineStore('review', () => {
           projectId: String(item.id),
           counterpartyId: String(item.employerId),
           projectName: item.projectName || getProjectFallbackLabel(item.id),
-          counterpartyName: item.employerName || `기업 #${item.employerId}`,
+          counterpartyName:
+            employerBusinessNames[String(item.id)] ||
+            item.employerName ||
+            employerNames[String(item.employerId)] ||
+            `기업 #${item.employerId}`,
         }));
 
       return freelancerReviewTargets.value;


### PR DESCRIPTION
## 🔗 Related Issue
- Closes #

## 📝 작업 내용
프리랜서 후기 작성 화면과 주요 목록 화면에서 데이터가 잘못 표시되거나 일부 항목이 누락되던 프론트 이슈를 수정했습니다. 제안 대상 ID 전달, 지원/제안 목록 노출, 리뷰 목록 렌더링, 후기 작성 대상 기업명 표시 로직을 함께 정리했습니다.

## ✅ Changes
- 프로필찾기 페이지의 제안하기 동작이 `freelancer` PK가 아닌 `freelancer.userId`를 사용하도록 수정
- 프리랜서가 고용주 제안을 거절할 때 표시되던 사유 입력창 제거
- 지원/제안 목록 화면에서 프론트의 추가 사용자 필터링을 제거해 서버에서 조회된 목록이 그대로 표시되도록 수정
- 리뷰 목록에서 일부 카드가 DOM에는 존재하지만 화면에서 보이지 않던 렌더링 문제 수정
- 프리랜서 후기 작성 화면에서 프로젝트 선택 시 기업명이 fallback 문자열로 보이지 않도록 표시 로직 보완

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
- 이번 PR은 프론트 표시/전달 로직 수정 중심입니다.
- 후기 작성 대상 기업명은 프론트에서 가능한 이름 소스를 우선 사용하도록 보완했습니다.
- 계약 API에서 mock 이름을 반환하던 백엔드 이슈는 별도 BE 수정과 함께 확인이 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 프리랜서 리뷰 대상에 고용주 정보 표시 개선: 고용주 ID 대신 고용주 비즈니스명 또는 고용주명을 우선적으로 표시하여 계약 정보의 가독성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->