### PR TITLE
HFP-109 fix: 채팅 색 및 지원/제안 글 수정

### DIFF
--- a/freebridgefe/src/components/chat/MessageBubble.vue
+++ b/freebridgefe/src/components/chat/MessageBubble.vue
@@ -35,7 +35,7 @@
                     class="flex min-w-[240px] items-center gap-3 px-4 py-3 text-[14px] shadow-md transition-all hover:shadow-lg"
                     :class="[
                         isMine
-                            ? 'bg-gradient-to-r from-[#21AFBF] to-[#00D4DA] text-white rounded-[22px] rounded-tr-sm'
+                            ? 'fb-chat-own-bubble rounded-[22px] rounded-tr-sm'
                             : 'bg-slate-800 border border-white/5 text-slate-200 rounded-[22px] rounded-tl-sm'
                     ]"
                 >
@@ -58,7 +58,7 @@
                     class="px-4 py-2 text-[14px] relative shadow-md transition-all hover:shadow-lg"
                     :class="[
                         isMine 
-                            ? 'bg-gradient-to-r from-[#21AFBF] to-[#00D4DA] text-white rounded-[22px] rounded-tr-sm' 
+                            ? 'fb-chat-own-bubble rounded-[22px] rounded-tr-sm' 
                             : 'bg-slate-800 border border-white/5 text-slate-200 rounded-[22px] rounded-tl-sm'
                     ]"
                 >
@@ -145,3 +145,18 @@ function formatFileSize(bytes: number) {
     return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 </script>
+
+<style scoped>
+.fb-chat-own-bubble {
+    background: linear-gradient(90deg, #21afbf 0%, #00d4da 100%);
+    color: #ffffff !important;
+    box-shadow: 0 14px 24px rgba(33, 175, 191, 0.22);
+}
+
+.fb-chat-own-bubble p,
+.fb-chat-own-bubble svg,
+.fb-chat-own-bubble a,
+.fb-chat-own-bubble span {
+    color: #ffffff !important;
+}
+</style>

--- a/freebridgefe/src/components/chat/MessageBubble.vue
+++ b/freebridgefe/src/components/chat/MessageBubble.vue
@@ -149,7 +149,7 @@ function formatFileSize(bytes: number) {
 <style scoped>
 .fb-chat-own-bubble {
     background: linear-gradient(90deg, #21afbf 0%, #00d4da 100%);
-    color: #ffffff !important;
+    color: #0f2b2e !important;
     box-shadow: 0 14px 24px rgba(33, 175, 191, 0.22);
 }
 
@@ -157,6 +157,6 @@ function formatFileSize(bytes: number) {
 .fb-chat-own-bubble svg,
 .fb-chat-own-bubble a,
 .fb-chat-own-bubble span {
-    color: #ffffff !important;
+    color: #0f2b2e !important;
 }
 </style>

--- a/freebridgefe/src/views/employer/Applications/ApplicationList.vue
+++ b/freebridgefe/src/views/employer/Applications/ApplicationList.vue
@@ -105,17 +105,17 @@ const statusConfig: Record<ApplicationStatus, { icon: any; label: string; gradie
   PENDING: {
     icon: Clock,
     label: '검토중',
-    gradient: 'from-blue-500 to-cyan-500',
+    gradient: 'from-sky-200 to-cyan-200',
   },
   ACCEPTED: {
     icon: CheckCircle,
     label: '수락됨',
-    gradient: 'from-green-500 to-emerald-500',
+    gradient: 'from-green-200 to-emerald-200',
   },
   REJECTED: {
     icon: XCircle,
     label: '거절됨',
-    gradient: 'from-red-500 to-red-600',
+    gradient: 'from-rose-200 to-red-200',
   },
 };
 
@@ -262,10 +262,10 @@ const openFreelancerProfile = async (freelancerId: string | number) => {
           >
             <div class="mb-5 flex flex-col items-start justify-between gap-6 lg:flex-row">
               <div class="flex-1">
-                <div class="mb-2 flex flex-wrap items-center gap-3">
+                <div class="mb-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <h3 class="text-2xl font-bold text-white">{{ proposal.freelancerName }}</h3>
                   <div
-                    class="flex items-center gap-2 rounded-full bg-gradient-to-r px-4 py-2 text-sm font-medium text-white shadow-lg"
+                    class="flex items-center gap-2 self-start rounded-full bg-gradient-to-r px-4 py-2 text-sm font-medium text-slate-900 shadow-sm sm:self-auto"
                     :class="statusConfig[proposal.status].gradient"
                   >
                     <component :is="statusConfig[proposal.status].icon" class="h-4 w-4" />
@@ -313,13 +313,13 @@ const openFreelancerProfile = async (freelancerId: string | number) => {
               v-if="proposal.status === 'REJECTED'"
               class="rounded-2xl border border-red-500/20 bg-red-500/10 p-4"
             >
-              <div class="mb-2 flex items-center gap-2 font-medium text-red-300">
-                <AlertCircle class="h-4 w-4" />
-                프리랜서가 제안을 거절했습니다.
-              </div>
-              <div v-if="proposal.rejectionReason" class="text-sm text-red-200">
-                사유: {{ proposal.rejectionReason }}
-              </div>
+                <div class="mb-2 flex items-center gap-2 font-semibold text-slate-900">
+                  <AlertCircle class="h-5 w-5 text-red-500" />
+                  프리랜서가 제안을 거절했습니다.
+                </div>
+                <div v-if="proposal.rejectionReason" class="text-sm text-slate-700">
+                  사유: {{ proposal.rejectionReason }}
+                </div>
             </div>
           </article>
         </div>
@@ -352,59 +352,57 @@ const openFreelancerProfile = async (freelancerId: string | number) => {
             :key="app.id"
             class="rounded-2xl border border-white/10 bg-slate-800/80 p-6 shadow-[0_10px_30px_rgba(0,0,0,0.18)]"
           >
-            <div class="mb-4 flex flex-col items-start justify-between gap-4 md:flex-row">
-              <div class="flex items-center gap-4">
-                <ProfileIdentityAvatar
-                  :label="app.freelancerName"
-                  variant="freelancer"
-                  shape="circle"
-                  size-class="h-14 w-14"
-                  text-class="text-xl font-bold"
-                  ring-class="shadow-lg"
-                />
-                <div>
-                  <div class="flex items-center gap-2 text-lg font-semibold text-white">
-                    {{ app.freelancerName }}
-                    <Sparkles class="h-4 w-4 text-yellow-400" />
+            <div class="mb-5 flex flex-col items-start justify-between gap-6 lg:flex-row">
+              <div class="flex-1">
+                <div class="mb-2 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                  <div class="flex items-center gap-4">
+                    <ProfileIdentityAvatar
+                      :label="app.freelancerName"
+                      variant="freelancer"
+                      shape="circle"
+                      size-class="h-14 w-14"
+                      text-class="text-xl font-bold"
+                      ring-class="shadow-lg"
+                    />
+                    <div>
+                      <div class="text-2xl font-bold text-white">{{ app.freelancerName }}</div>
+                      <div class="mb-2 flex items-center gap-2 text-white/80">
+                        <Sparkles class="h-4 w-4 text-yellow-400" />
+                        <span>{{ formatDate(app.createdAt) }} 지원</span>
+                      </div>
+                      <div class="text-sm text-white/85">
+                        지원 공고: {{ getJobTitle(app.jobId) }}
+                      </div>
+                    </div>
                   </div>
-                  <div class="text-sm text-white/80">
-                    {{ formatDate(app.createdAt) }} 지원
-                  </div>
-                  <div class="mt-1 text-sm text-white/85">
-                    지원 공고: {{ getJobTitle(app.jobId) }}
-                  </div>
-                  <button
-                    type="button"
-                    class="mt-1 flex items-center gap-1 text-sm text-blue-400 hover:text-blue-300 hover:underline"
-                    @click="openFreelancerProfile(app.freelancerId)"
-                  >
-                    프로필 및 포트폴리오 보기
-                  </button>
-                </div>
-              </div>
 
-              <div v-if="app.status === 'PENDING'" class="flex gap-2">
-                <button
-                  @click="handleAccept(app)"
-                  class="flex items-center gap-2 rounded-full bg-gradient-to-r from-green-500 to-emerald-500 px-5 py-2.5 font-medium text-white transition-all hover:shadow-lg"
-                >
-                  <Check class="h-4 w-4" />
-                  수락
-                </button>
-                <button
-                  @click="handleReject(app)"
-                  class="flex items-center gap-2 rounded-full bg-gradient-to-r from-red-500 to-red-600 px-5 py-2.5 font-medium text-white transition-all hover:shadow-lg"
-                >
-                  <X class="h-4 w-4" />
-                  거절
-                </button>
-              </div>
-              <div
-                v-else
-                class="rounded-full border px-5 py-2.5 font-medium"
-                :class="app.status === 'ACCEPTED' ? 'border-green-500/30 bg-green-500/20 text-green-300' : 'border-red-500/30 bg-red-500/20 text-red-300'"
-              >
-                {{ app.status === 'ACCEPTED' ? '수락됨' : '거절됨' }}
+                  <div v-if="app.status === 'PENDING'" class="flex gap-2 self-start sm:self-auto">
+                    <button
+                      @click="handleAccept(app)"
+                      class="flex items-center gap-2 rounded-full bg-gradient-to-r from-green-500 to-emerald-500 px-5 py-2.5 font-medium text-white transition-all hover:shadow-lg"
+                    >
+                      <Check class="h-4 w-4" />
+                      수락
+                    </button>
+                    <button
+                      @click="handleReject(app)"
+                      class="flex items-center gap-2 rounded-full bg-gradient-to-r from-red-500 to-red-600 px-5 py-2.5 font-medium text-white transition-all hover:shadow-lg"
+                    >
+                      <X class="h-4 w-4" />
+                      거절
+                    </button>
+                  </div>
+                  <div
+                    v-else
+                    class="flex items-center gap-2 self-start rounded-full border bg-gradient-to-r px-4 py-2 text-sm font-medium text-slate-900 shadow-sm sm:self-auto"
+                    :class="app.status === 'ACCEPTED'
+                      ? 'border-green-300/60 from-green-200 to-emerald-200'
+                      : 'border-red-300/60 from-rose-200 to-red-200'"
+                  >
+                    <component :is="app.status === 'ACCEPTED' ? CheckCircle : XCircle" class="h-4 w-4" />
+                    {{ app.status === 'ACCEPTED' ? '수락됨' : '거절됨' }}
+                  </div>
+                </div>
               </div>
             </div>
 
@@ -415,7 +413,15 @@ const openFreelancerProfile = async (freelancerId: string | number) => {
               </div>
             </div>
 
-            <div v-if="app.portfolioUrl || app.resumeUrl" class="mb-4 flex gap-3">
+            <div class="mb-4 flex flex-wrap items-center gap-4">
+              <button
+                type="button"
+                class="flex items-center gap-1 text-sm font-medium text-blue-400 hover:text-blue-300"
+                @click="openFreelancerProfile(app.freelancerId)"
+              >
+                프로필 보기
+              </button>
+
               <a
                 v-if="app.portfolioUrl"
                 :href="app.portfolioUrl"
@@ -438,10 +444,16 @@ const openFreelancerProfile = async (freelancerId: string | number) => {
               </a>
             </div>
 
-            <div v-if="app.status === 'REJECTED' && app.rejectionReason" class="border-t border-white/10 pt-4">
-              <div class="mb-2 text-sm text-white/80">거절 사유</div>
-              <div class="rounded-2xl border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-300">
-                {{ app.rejectionReason }}
+            <div
+              v-if="app.status === 'REJECTED'"
+              class="rounded-2xl border border-red-500/20 bg-red-500/10 p-4"
+            >
+              <div class="mb-2 flex items-center gap-2 font-semibold text-slate-900">
+                <AlertCircle class="h-5 w-5 text-red-500" />
+                프리랜서 지원서를 거절했습니다.
+              </div>
+              <div v-if="app.rejectionReason" class="text-sm text-slate-700">
+                사유: {{ app.rejectionReason }}
               </div>
             </div>
           </article>

--- a/freebridgefe/src/views/employer/Applications/ApplicationList.vue
+++ b/freebridgefe/src/views/employer/Applications/ApplicationList.vue
@@ -303,8 +303,8 @@ const openFreelancerProfile = async (freelancerId: string | number) => {
               v-if="proposal.status === 'ACCEPTED'"
               class="flex items-center gap-3 rounded-2xl border border-green-500/20 bg-green-500/10 p-4"
             >
-              <CheckCircle class="h-5 w-5 text-green-400" />
-              <span class="font-medium text-green-300">
+              <CheckCircle class="h-5 w-5 text-green-600" />
+              <span class="font-semibold text-slate-900">
                 프리랜서가 제안을 수락했습니다. 계약 진행을 시작해 주세요.
               </span>
             </div>

--- a/freebridgefe/src/views/employer/Contracts/ContractsView.vue
+++ b/freebridgefe/src/views/employer/Contracts/ContractsView.vue
@@ -93,26 +93,26 @@ const filteredAndSortedContracts = computed(() => {
 
 const statusConfig: Record<
     string,
-    { label: string; bgColor: string; icon: typeof CheckCircle }
+    { label: string; badgeClass: string; icon: typeof CheckCircle }
 > = {
     WAITING_SIGNATURE: {
         label: '서명 대기',
-        bgColor: 'bg-orange-500',
+        badgeClass: 'border border-orange-200/80 bg-orange-50 text-slate-700',
         icon: Clock,
     },
     IN_PROGRESS: {
         label: '진행 중',
-        bgColor: 'bg-blue-500',
+        badgeClass: 'border border-sky-200/80 bg-sky-50 text-slate-700',
         icon: TrendingUp,
     },
     COMPLETED: {
         label: '완료',
-        bgColor: 'bg-green-500',
+        badgeClass: 'border border-emerald-200/80 bg-emerald-50 text-slate-700',
         icon: CheckCircle,
     },
     REJECTED: {
         label: '거절됨',
-        bgColor: 'bg-rose-500',
+        badgeClass: 'border border-rose-200/80 bg-rose-50 text-slate-700',
         icon: Clock,
     },
 };
@@ -358,11 +358,11 @@ watch(
             >
                 <!-- Header -->
                 <div class="mb-8">
-                    <div class="flex items-center gap-3 mb-3 flex-wrap">
+                    <div class="mb-3 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                         <h2 class="text-3xl font-bold">{{ contract.projectName }}</h2>
                         <div
                             v-if="statusConfig[contract.status]"
-                            :class="`px-4 py-2 rounded-full ${statusConfig[contract.status].bgColor} text-white text-sm font-medium shadow-lg flex items-center gap-2`"
+                            :class="`ml-auto flex items-center gap-2 self-end rounded-full px-4 py-2 text-sm font-medium shadow-sm ${statusConfig[contract.status].badgeClass}`"
                         >
                             <component
                                 :is="statusConfig[contract.status].icon"

--- a/freebridgefe/src/views/employer/Freelancers/FreelancerSearchView.vue
+++ b/freebridgefe/src/views/employer/Freelancers/FreelancerSearchView.vue
@@ -338,7 +338,7 @@ onMounted(() => {
           <button
             type="button"
             @click="applyFilters"
-            class="ml-auto px-4 py-2 rounded-lg bg-emerald-400 text-black font-semibold hover:bg-emerald-300 transition-colors"
+            class="ml-auto rounded-lg bg-gradient-to-r from-[#21AFBF] to-[#00D4DA] px-4 py-2 font-semibold text-[#0f2b2e] transition-all hover:brightness-105"
           >
             검색
           </button>
@@ -382,7 +382,7 @@ onMounted(() => {
         @keyup.space.self.prevent="openFreelancerProfile(freelancer)"
       >
         <div class="flex items-start gap-4 mb-4">
-          <div class="w-14 h-14 rounded-full bg-gradient-to-br from-emerald-400 to-teal-500 overflow-hidden flex items-center justify-center text-white text-2xl font-bold">
+          <div class="w-14 h-14 rounded-full bg-gradient-to-br from-[#21AFBF] to-[#00D4DA] overflow-hidden flex items-center justify-center text-white text-2xl font-bold">
             <img
               v-if="freelancer.avatarUrl"
               :src="freelancer.avatarUrl"
@@ -396,7 +396,7 @@ onMounted(() => {
               <div class="text-xl font-semibold">{{ freelancer.name }}</div>
               <span
                 v-if="freelancer.grade"
-                class="px-2 py-0.5 rounded-full border border-emerald-400/20 bg-emerald-400/10 text-xs text-emerald-300"
+                class="px-2 py-0.5 rounded-full border border-[#21AFBF]/20 bg-[#21AFBF]/10 text-xs text-[#21AFBF]"
               >
                 {{ freelancer.grade }}
               </span>
@@ -417,7 +417,7 @@ onMounted(() => {
           <span
             v-for="skill in formatSkills(freelancer.skills)"
             :key="skill"
-            class="px-3 py-1 bg-emerald-400/10 text-emerald-300 text-xs rounded-full border border-emerald-400/20"
+            class="px-3 py-1 bg-[#21AFBF]/10 text-[#21AFBF] text-xs rounded-full border border-[#21AFBF]/20"
           >
             {{ skill }}
           </span>
@@ -433,18 +433,18 @@ onMounted(() => {
               @click.stop="toggleFavorite(freelancer.freelancerId)"
               class="px-3 py-2 rounded-lg border transition-all"
               :class="isFavorite(freelancer.freelancerId)
-                ? 'bg-yellow-400/20 border-yellow-400/40 text-yellow-300'
+                ? 'bg-[#21AFBF]/12 border-[#21AFBF]/35 text-[#21AFBF]'
                 : 'bg-white/5 border-white/10 text-white/60 hover:bg-white/10'"
             >
               <Star
                 class="w-4 h-4"
-                :class="isFavorite(freelancer.freelancerId) ? 'fill-yellow-400 text-yellow-400' : ''"
+                :class="isFavorite(freelancer.freelancerId) ? 'fill-[#21AFBF] text-[#21AFBF]' : ''"
               />
             </button>
             <button
               type="button"
               @click.stop="selectedFreelancer = toProposalFreelancer(freelancer)"
-              class="px-4 py-2 bg-emerald-400 text-black rounded-lg font-semibold hover:bg-emerald-300 transition-colors flex items-center gap-2"
+              class="px-4 py-2 bg-gradient-to-r from-[#21AFBF] to-[#00D4DA] text-[#0f2b2e] rounded-lg font-semibold hover:brightness-105 transition-all flex items-center gap-2"
             >
               <Send class="w-4 h-4" />
               제안하기

--- a/freebridgefe/src/views/employer/Review/ReviewList.vue
+++ b/freebridgefe/src/views/employer/Review/ReviewList.vue
@@ -225,7 +225,7 @@ onMounted(() => {
                 {{ item.label }} <span class="text-white font-medium ml-1">{{ review[item.key] }}</span>
               </div>
             </div>
-            <p class="text-white/80 leading-relaxed bg-black/20 rounded-xl p-4">
+            <p class="rounded-xl border border-slate-200 bg-slate-50 p-4 leading-relaxed text-slate-700">
               {{ review.comment }}
             </p>
 
@@ -349,7 +349,7 @@ onMounted(() => {
                 {{ item.label }} <span class="text-white font-medium ml-1">{{ review[item.key] }}</span>
               </div>
             </div>
-            <p class="text-white/80 leading-relaxed bg-black/20 rounded-xl p-4">
+            <p class="rounded-xl border border-slate-200 bg-slate-50 p-4 leading-relaxed text-slate-700">
               {{ review.comment }}
             </p>
           </div>

--- a/freebridgefe/src/views/freelancer/MyPage/components/CompanyEvaluationSummary.vue
+++ b/freebridgefe/src/views/freelancer/MyPage/components/CompanyEvaluationSummary.vue
@@ -227,8 +227,8 @@ const overallRating = computed(() => {
                     </div>
                 </div>
 
-                <p class="text-white/80 leading-relaxed bg-black/20 rounded-xl p-4">
-                    {{ review.comment }}
+                <p class="rounded-xl border border-slate-200 bg-slate-50 p-4 leading-relaxed text-slate-700">
+                  {{ review.comment }}
                 </p>
             </div>
 


### PR DESCRIPTION
# 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 채팅 메시지 버블에 통일된 그래디언트와 텍스트/아이콘 색상 규칙이 적용되었습니다.
  * 지원서 목록의 상태 배지, 헤더 레이아웃과 수락/거절 배너 스타일이 개선되었습니다.
  * 계약 카드의 상태 배지 디자인과 헤더 배치가 더 깔끔해졌습니다.
  * 프리랜서 검색 화면의 버튼·아바타·버튼 색상 팔레트가 업데이트되었습니다.
  * 후기 목록과 기업 평가의 코멘트 카드가 밝고 테두리 있는 스타일로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->