### PR TITLE
HFP-125 [fix] 채팅 파일전송 용량 제한 확장

### DIFF
--- a/freebridgefe/src/stores/chatStore.ts
+++ b/freebridgefe/src/stores/chatStore.ts
@@ -372,7 +372,7 @@ export const useChatStore = defineStore('chat', () => {
                     client.connectHeaders = latestToken
                         ? { Authorization: `Bearer ${latestToken}` }
                         : {};
-                    client.reconnectDelay = latestToken ? STOMP_RECONNECT_DELAY_MS : 0;
+                    client.reconnectDelay = STOMP_RECONNECT_DELAY_MS;
                 },
                 reconnectDelay: STOMP_RECONNECT_DELAY_MS,
                 onConnect: () => {

--- a/freebridgefe/src/stores/chatStore.ts
+++ b/freebridgefe/src/stores/chatStore.ts
@@ -18,6 +18,7 @@ import { CHAT_MUTED_ROOMS_KEY } from '@/constants/chatUi';
 
 export const useChatStore = defineStore('chat', () => {
     const authStore = useAuthStore();
+    const STOMP_RECONNECT_DELAY_MS = 5000;
 
     type OutboundChatMessagePayload = {
         roomId: string;
@@ -366,7 +367,14 @@ export const useChatStore = defineStore('chat', () => {
                 connectHeaders: {
                     Authorization: `Bearer ${token}`
                 },
-                reconnectDelay: 5000,
+                beforeConnect: (client) => {
+                    const latestToken = getAccessToken();
+                    client.connectHeaders = latestToken
+                        ? { Authorization: `Bearer ${latestToken}` }
+                        : {};
+                    client.reconnectDelay = latestToken ? STOMP_RECONNECT_DELAY_MS : 0;
+                },
+                reconnectDelay: STOMP_RECONNECT_DELAY_MS,
                 onConnect: () => {
                     console.log('[STOMP] Connected');
                     if (currentRoomId.value) {


### PR DESCRIPTION
## 🔗 Related Issue
> 이슈 번호를 작성해주세요. (예: Closes #123)
- Closes #157 

## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
* 현재 채팅에서 보낼수 있는 1MB 이하 파일만 보낼 수 있는 문제가 있었다 . 이를 수정하였다. 
## ✅ Changes
> 주요 변경 사항을 bullet point로 정리합니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이나 테스트 결과 화면이 있다면 첨부해주세요.
<img width="500" alt="스크린샷" src="">

## ⚠️ Notes (Optional)
> 리뷰 시 유의할 점, 후속 PR 예정 사항, 배포 영향 등을 적습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * WebSocket 재연결 지연 동작을 안정화했습니다.
  * 연결 시점에 액세스 토큰을 자동으로 갱신해 최신 자격으로 연결하도록 개선했습니다.
  * 토큰 유무에 따른 지능형 재연결 로직을 적용해 재연결 실패 가능성을 낮췄습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->